### PR TITLE
feature/11733-12614-altera-status-inicial-proponente

### DIFF
--- a/sme_uniforme_apps/proponentes/models/proponente.py
+++ b/sme_uniforme_apps/proponentes/models/proponente.py
@@ -47,15 +47,18 @@ class Proponente(ModeloBase):
     # Status Choice
     STATUS_INSCRITO = 'INSCRITO'
     STATUS_BLOQUEADO = 'BLOQUEADO'
+    STATUS_EM_PROCESSO = 'EM_PROCESSO'
 
     STATUS_NOMES = {
         STATUS_INSCRITO: 'Inscrito',
         STATUS_BLOQUEADO: 'Bloqueado',
+        STATUS_EM_PROCESSO: 'Em processo'
     }
 
     STATUS_CHOICES = (
         (STATUS_INSCRITO, STATUS_NOMES[STATUS_INSCRITO]),
         (STATUS_BLOQUEADO, STATUS_NOMES[STATUS_BLOQUEADO]),
+        (STATUS_EM_PROCESSO, STATUS_NOMES[STATUS_EM_PROCESSO]),
     )
 
     cnpj = models.CharField(
@@ -106,7 +109,7 @@ class Proponente(ModeloBase):
         'status',
         max_length=15,
         choices=STATUS_CHOICES,
-        default=STATUS_INSCRITO
+        default=STATUS_EM_PROCESSO
     )
 
     def __str__(self):
@@ -152,9 +155,10 @@ def proponente_post_save(instance, created, **kwargs):
 
 @receiver(pre_save, sender=Proponente)
 def proponente_pre_save(instance, **kwargs):
-    if instance.cnpj and cnpj_esta_bloqueado(instance.cnpj):
+    if instance.status == Proponente.STATUS_INSCRITO and instance.cnpj and cnpj_esta_bloqueado(instance.cnpj):
         instance.status = Proponente.STATUS_BLOQUEADO
-    else:
+
+    elif instance.status == Proponente.STATUS_BLOQUEADO and instance.cnpj and not cnpj_esta_bloqueado(instance.cnpj):
         instance.status = Proponente.STATUS_INSCRITO
 
 

--- a/sme_uniforme_apps/proponentes/tests/conftest.py
+++ b/sme_uniforme_apps/proponentes/tests/conftest.py
@@ -3,6 +3,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from model_bakery import baker
 
 from ...core.models import Uniforme
+from ..models.proponente import Proponente
 
 
 @pytest.fixture
@@ -89,6 +90,7 @@ def proponente_bloqueado(cnpj_bloqueado, lista_negra):
         telefone='(99) 99999-8888',
         email='bloqueado@teste.com',
         responsavel='José Bloqueio da Silva',
+        status=Proponente.STATUS_INSCRITO
     )
 
 

--- a/sme_uniforme_apps/proponentes/tests/test_integracao_bloqueio_proponente.py
+++ b/sme_uniforme_apps/proponentes/tests/test_integracao_bloqueio_proponente.py
@@ -8,8 +8,8 @@ from ..models import Proponente, ListaNegra
 pytestmark = pytest.mark.django_db
 
 
-def test_bloqueia_ao_cadastrar_proponente_com_cnpj_bloqueado(lista_negra, cnpj_bloqueado):
-    # Ao criar um proponente cujo CNPJ esteja na lista negra o seu status deve ficar como BLOQUEADO
+def test_nao_bloqueia_ao_cadastrar_proponente_com_cnpj_bloqueado(lista_negra, cnpj_bloqueado):
+    # Ao criar um proponente cujo CNPJ está na lista negra o status deve ficar como EM_PROCESSO e não como BLOQUEADO
     novo_proponente = baker.make(
         'Proponente',
         cnpj=cnpj_bloqueado,
@@ -23,12 +23,38 @@ def test_bloqueia_ao_cadastrar_proponente_com_cnpj_bloqueado(lista_negra, cnpj_b
         responsavel='José Bloqueio da Silva',
     )
 
-    assert novo_proponente.status == Proponente.STATUS_BLOQUEADO
+    assert novo_proponente.status == Proponente.STATUS_EM_PROCESSO
+
+
+def test_bloqueia_ao_concluir_cadastro_de_proponente_com_cnpj_bloqueado(lista_negra, cnpj_bloqueado):
+    # Ao concluir o cadastro de um proponente cujo CNPJ esteja na lista negra o seu status deve ficar como BLOQUEADO
+    novo_proponente = baker.make(
+        'Proponente',
+        cnpj=cnpj_bloqueado,
+        razao_social='Teste Bloqueado',
+        end_logradouro='Rua Bloqueio, 123 apt. 101 Centro',
+        end_cidade='São Paulo',
+        end_uf='SP',
+        end_cep='99999-000',
+        telefone='(99) 99999-8888',
+        email='bloqueado@teste.com',
+        responsavel='José Bloqueio da Silva',
+    )
+
+    assert novo_proponente.status == Proponente.STATUS_EM_PROCESSO
+
+    novo_proponente.status = Proponente.STATUS_INSCRITO
+    novo_proponente.save()
+
+    proponente = Proponente.objects.get(id=novo_proponente.id)
+    assert proponente.status == Proponente.STATUS_BLOQUEADO
 
 
 def test_desbloqueia_ao_atualizar_proponente_sem_cnpj_bloqueado(proponente_bloqueado, cnpj_bloqueado):
     assert proponente_bloqueado.status == Proponente.STATUS_BLOQUEADO
     ListaNegra.objects.get(cnpj=cnpj_bloqueado).delete()
     proponente_bloqueado.save()
-    assert proponente_bloqueado.status == Proponente.STATUS_INSCRITO
+    proponente = Proponente.objects.get(id=proponente_bloqueado.id)
+    assert proponente.status == Proponente.STATUS_INSCRITO
+
 

--- a/sme_uniforme_apps/proponentes/tests/test_proponente_model.py
+++ b/sme_uniforme_apps/proponentes/tests/test_proponente_model.py
@@ -72,8 +72,8 @@ def test_cnpj_valido_resultado_negativo():
     assert not Proponente.cnpj_valido(cnpj_invalido)
 
 
-def test_proponente_status_default_inscrito(proponente):
-    assert proponente.status == Proponente.STATUS_INSCRITO
+def test_proponente_status_default_em_processo(proponente):
+    assert proponente.status == Proponente.STATUS_EM_PROCESSO
 
 
 def test_proponente_delete(proponente, loja_fisica, oferta_de_uniforme, anexo):


### PR DESCRIPTION
Esse PR:

- Cria o status EM_PROCESSO para o Proponente.
- Modifica o status inicial de um proponente para EM_PROCESSO
- Altera lógica de bloqueio por CNPJ para só bloquear quando o status passar para INSCRITO.