### PR TITLE
feature/11733-12616-enviar-email-na-conclusao-do-cadastro 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,8 @@ celery  -A config beat --loglevel=info
 ```console
 flower -A config --port=5555
 ```
+
+**Limpar os processos no celery**
+```console
+celery  -A config purge
+```

--- a/sme_uniforme_apps/proponentes/models/proponente.py
+++ b/sme_uniforme_apps/proponentes/models/proponente.py
@@ -144,6 +144,7 @@ class Proponente(ModeloBase):
         proponente = Proponente.objects.get(uuid=uuid)
         proponente.status = Proponente.STATUS_INSCRITO
         proponente.save()
+        enviar_email_confirmacao_cadastro.delay(proponente.email, {'protocolo': proponente.protocolo})
 
     class Meta:
         verbose_name = "Proponente"
@@ -152,11 +153,9 @@ class Proponente(ModeloBase):
 
 @receiver(post_save, sender=Proponente)
 def proponente_post_save(instance, created, **kwargs):
-    if created and instance and instance.email:
-        enviar_email_confirmacao_cadastro.delay(instance.email, {'protocolo': instance.protocolo})
-
-    # if created and instance and instance.email and instance.responsavel:
-    #     cria_usuario_novo_proponente(instance)
+    ...
+    # if created and instance and instance.email:
+    #     enviar_email_confirmacao_cadastro.delay(instance.email, {'protocolo': instance.protocolo})
 
 
 @receiver(pre_save, sender=Proponente)


### PR DESCRIPTION
Esse PR:
- Altera o momento de envio do e-mail de confirmação de inscrição para a conclusão do cadastro.

O e-mail de confirmação de inscrição, com o protocolo, não é mais enviado na criação do proponente, mas na conclusão do cadastro.
