### PR TITLE
Endpoint /tipos-documento retorna apenas visiveis

### DIFF
--- a/sme_uniforme_apps/proponentes/api/viewsets/tipos_documento_viewset.py
+++ b/sme_uniforme_apps/proponentes/api/viewsets/tipos_documento_viewset.py
@@ -9,7 +9,7 @@ from ...models import TipoDocumento
 
 class TiposDocumentoViewSet(viewsets.ReadOnlyModelViewSet):
     lookup_field = 'id'
-    queryset = TipoDocumento.objects.all()
+    queryset = TipoDocumento.objects.filter(visivel=True).all()
     serializer_class = TipoDocumentoSerializer
     permission_classes = [AllowAny]
     filter_backends = (filters.DjangoFilterBackend, SearchFilter, OrderingFilter)

--- a/sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipos_documento_endpoint.py
+++ b/sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipos_documento_endpoint.py
@@ -4,6 +4,6 @@ from rest_framework import status
 pytestmark = pytest.mark.django_db
 
 
-def test_url_authorized(authenticated_client):
+def test_url_authorized(authenticated_client, tipo_documento):
     response = authenticated_client.get('/tipos-documento/')
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Esse PR contém:

- /tipos-documento retorna apenas  tipos "visiveis"