### PR TITLE
Feature/11733 12615 enviar email pre cadastro

### DIFF
--- a/sme_uniforme_apps/proponentes/tasks.py
+++ b/sme_uniforme_apps/proponentes/tasks.py
@@ -22,3 +22,18 @@ def enviar_email_confirmacao_cadastro(email, contexto):
         contexto,
         email
     )
+
+
+@shared_task(
+    autoretry_for=(SMTPServerDisconnected,),
+    retry_backoff=2,
+    retry_kwargs={'max_retries': 8},
+)
+def enviar_email_confirmacao_pre_cadastro(email, contexto):
+    print(f'Confirmação de pré-cadastro (Protocolo:{contexto["protocolo"]}) enviada para {email}.')
+    return enviar_email_html(
+        'Pré-cadastro realizado. Finalize seu cadastro!',
+        'email_confirmacao_pre_cadastro',
+        contexto,
+        email
+    )

--- a/sme_uniforme_apps/proponentes/tasks.py
+++ b/sme_uniforme_apps/proponentes/tasks.py
@@ -17,7 +17,7 @@ env = environ.Env()
 def enviar_email_confirmacao_cadastro(email, contexto):
     print(f'Confirmação de cadastro (Protocolo:{contexto["protocolo"]}) enviada para {email}.')
     return enviar_email_html(
-        'Recebemos o seu cadastro',
+        'Obrigado pelo envio do seu cadastro',
         'email_confirmacao_cadastro',
         contexto,
         email

--- a/sme_uniforme_apps/proponentes/templates/email/email_confirmacao_cadastro.html
+++ b/sme_uniforme_apps/proponentes/templates/email/email_confirmacao_cadastro.html
@@ -2,14 +2,13 @@
 {% block content %}
     <div class="row">
         <div class="col-12 p-2">
-
-            Caro fornecedor,<br/><br/>
-            Recebemos sua inscrição sob número de protocolo {{ protocolo }}. A área técnica da Secretaria
-            Municipal de
-            Educação analisará o seu cadastro e enviará parecer neste mesmo
-            email. Favor aguardar nosso contato.
-            <br/>
-            <br/>
+            <p>Caro fornecedor,</p>
+            <p>
+                Recebemos sua inscrição sob número de protocolo {{ protocolo }}. A área técnica da Secretaria
+                Municipal de
+                Educação analisará o seu cadastro e enviará parecer neste mesmo
+                email. Favor aguardar nosso contato.
+            </p>
         </div>
     </div>
 {% endblock %}

--- a/sme_uniforme_apps/proponentes/templates/email/email_confirmacao_pre_cadastro.html
+++ b/sme_uniforme_apps/proponentes/templates/email/email_confirmacao_pre_cadastro.html
@@ -1,0 +1,22 @@
+{% extends "base/page.html" %}
+{% block content %}
+    <div class="row">
+        <div class="col-12 p-2">
+
+            <p>Caro fornecedor,</p>
+            <p>
+                Recebemos o seu pré-cadastro com sucesso. Porém, para se tornar um fornecedor de uniformes da Rede
+                Municipal de Ensino é necessário finalizar seu cadastro, completando-o com mais algumas informações
+                necessárias.
+            </p>
+            <p>Para finalizar o seu cadastro, <a href="{{ url_cadastro }}">clique aqui</a>.</p>
+            <p>
+                Após finalizar o cadastro, você receberá o número de protocolo para identificação da solicitação.
+            </p>
+            <p>
+                Caso você já tenha finalizado o cadastro e já tenha o número de protocolo, favor desconsiderar esse
+                e-mail.
+            </p>
+        </div>
+    </div>
+{% endblock %}

--- a/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponente_envio_emails.py
+++ b/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponente_envio_emails.py
@@ -1,0 +1,21 @@
+import pytest
+from unittest.mock import patch
+from model_bakery import baker
+
+from ...models.proponente import Proponente
+
+pytestmark = pytest.mark.django_db
+
+
+@patch('sme_uniforme_apps.proponentes.models.proponente.Proponente.comunicar_pre_cadastro')
+def test_comunica_pre_cadastro(mock_comunicar_pre_cadastro):
+    baker.make('Proponente')
+    assert mock_comunicar_pre_cadastro.called
+
+
+@patch('sme_uniforme_apps.proponentes.models.proponente.Proponente.comunicar_cadastro')
+def test_comunica_cadastro(mock_comunicar_cadastro):
+    proponente = baker.make('Proponente')
+    Proponente.concluir_cadastro(proponente.uuid)
+    assert mock_comunicar_cadastro.called
+

--- a/sme_uniforme_apps/templates/base/footer.html
+++ b/sme_uniforme_apps/templates/base/footer.html
@@ -1,5 +1,9 @@
 <footer class="footer">
-    <div class="container text-center p-5">
-      <span class="text-muted ">Prefeitura da Cidade de São Paulo</span>
-    </div>
+    <p>
+        Atenciosamente,
+    </p>
+    <p>
+        Secretaria Municipal de Educação </br>
+        Prefeitura da Cidade de São Paulo
+    </p>
 </footer>


### PR DESCRIPTION
Esse PR:
- Implementa o envio do e-mail de pré-cadastro, informando o lojista que o pré-cadastro foi realizado e fornecendo um link para acesso à página onde serão feitos os uploads dos documentos.
- Faz alteração do título do e-mail de cadastro, para ficar em conformidade com o Figma.