### PR TITLE
feature/11733-12615-enviar-email-pre-cadastro-remove-barra 

### DIFF
--- a/sme_uniforme_apps/proponentes/models/proponente.py
+++ b/sme_uniforme_apps/proponentes/models/proponente.py
@@ -120,7 +120,7 @@ class Proponente(ModeloBase):
     def comunicar_pre_cadastro(self):
         if self.email:
             env = environ.Env()
-            url = f'https://{env("SERVER_NAME")}/cadastro/?uuid={self.uuid}'
+            url = f'https://{env("SERVER_NAME")}/cadastro?uuid={self.uuid}'
             enviar_email_confirmacao_pre_cadastro.delay(self.email,
                                                         {'protocolo': self.protocolo, 'url_cadastro': url})
 


### PR DESCRIPTION
Esse PR:
- Remove a barra antes do parâmetro da url do e-mail de pré-cadastro.

A URL para o lojista completar o cadastro passa a ser /cadastro?uuid=[uuid do proponente]