### PR TITLE
Feature/11733 12721 inverte atributos visivel obrigatorio tipos doc

### DIFF
--- a/sme_uniforme_apps/proponentes/admin.py
+++ b/sme_uniforme_apps/proponentes/admin.py
@@ -90,7 +90,26 @@ class LojaAdmin(admin.ModelAdmin):
 
 @admin.register(TipoDocumento)
 class TipoDocumentoAdmin(admin.ModelAdmin):
+    def inverte_visivel(self, request, queryset):
+        for tipo_documento in queryset.all():
+            tipo_documento.visivel = not tipo_documento.visivel
+            tipo_documento.save()
+
+        self.message_user(request, "Parâmetro 'visível' atualizado.")
+
+    inverte_visivel.short_description = "Inverter o parâmetro 'visível' "
+
+    def inverte_obrigatorio(self, request, queryset):
+        for tipo_documento in queryset.all():
+            tipo_documento.obrigatorio = not tipo_documento.obrigatorio
+            tipo_documento.save()
+
+        self.message_user(request, "Parâmetro 'obrigatório' atualizado.")
+
+    inverte_obrigatorio.short_description = "Inverter o parâmetro 'obrigatório' "
+
     list_display = ('nome', 'obrigatorio', 'visivel')
     ordering = ('nome',)
     search_fields = ('nome',)
     list_filter = ('obrigatorio', 'visivel')
+    actions = ['inverte_visivel', 'inverte_obrigatorio']


### PR DESCRIPTION
Esse PR:
- Cria no Admin de Tipos de Documento ações para possibilitar a troca em massa dos parâmetros 'visível' e 'obrigatório' dos tipos de documento.