### PR TITLE
feature/11733_12773-Alrerar-senha-user-no-admin 

### DIFF
--- a/sme_uniforme_apps/custom_user/admin.py
+++ b/sme_uniforme_apps/custom_user/admin.py
@@ -1,33 +1,6 @@
 from django.contrib import admin
+from django_use_email_as_username.admin import BaseUserAdmin
 
 from .models import User
 
-
-@admin.register(User)
-class CustomUserAdmin(admin.ModelAdmin):
-    """Define admin model for custom User model with no email field."""
-
-    fieldsets = (
-        (None, {"fields": ("email", "password", 'validado')}),
-        ("Personal info", {"fields": ("first_name", "last_name")}),
-        (
-            "Permissions",
-            {
-                "fields": (
-                    "is_active",
-                    "is_staff",
-                    "is_superuser",
-                    "groups",
-                    "user_permissions",
-                )
-            },
-        ),
-        ("Important dates", {"fields": ("last_login", "date_joined")}),
-    )
-    add_fieldsets = (
-        (None, {"classes": ("wide",), "fields": ("email", "password1", "password2")}),
-    )
-    list_display = ("email", "first_name", "last_name", "is_staff", "validado")
-    search_fields = ("email", "first_name", "last_name")
-    ordering = ("email",)
-    list_filter = ("validado",)
+admin.site.register(User, BaseUserAdmin)


### PR DESCRIPTION
Esse PR:
- Ajusta o form do Admin para usuários que não estava permitindo alterar a senha de um usuário. 
Isso ocorria devido a customização para login por e-mail.