### PR TITLE
feature/13280-retorno-versao-publico

### DIFF
--- a/sme_uniforme_apps/core/api/viewsets/version_viewset.py
+++ b/sme_uniforme_apps/core/api/viewsets/version_viewset.py
@@ -1,9 +1,11 @@
 from rest_framework import viewsets
+from rest_framework.permissions import AllowAny
 from utility.api_version import API_VERSION
 from rest_framework.response import Response
 
 
 class ApiVersion(viewsets.ViewSet):
+    permission_classes = [AllowAny]
 
     def list(self, request):
         return Response({'API_Version': API_VERSION})


### PR DESCRIPTION
Esse PR:
- Torna público o end-point api-version

O endpoint api-version estava requerendo autenticação, mas ele precisa ser público.