### PR TITLE
feat(19632): CNPJ e Razao Social Read Only na edição de proponentes

### DIFF
--- a/sme_uniforme_apps/proponentes/admin.py
+++ b/sme_uniforme_apps/proponentes/admin.py
@@ -105,7 +105,7 @@ class ProponenteAdmin(admin.ModelAdmin):
     search_fields = ('uuid', 'cnpj', 'razao_social', 'responsavel')
     list_filter = ('status',)
     inlines = [UniformesFornecidosInLine, LojasInLine, AnexosInLine]
-    readonly_fields = ('uuid', 'id')
+    readonly_fields = ('uuid', 'id', 'cnpj', 'razao_social')
 
 
 @admin.register(OfertaDeUniforme)


### PR DESCRIPTION
Esse PR:
- Altera o cadastro de proponentes no Admin colocando osa campos Razão Social e CNPJ como apenas leitura. 