### PR TITLE
Feature(148711): Validação Análise IA - Anexos

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,17 @@ pytest.ini
 README.md
 README.rst
 setup.cfg
+.git
+.venv
+.run
+.idea
+.vscode
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+build/
+dist/
+docs/_build/

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,9 @@ dmypy.json
 
 # Media folder
 media/
+
+# run
+.run/
+
+#github
+.github/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,28 @@
+FROM python:3.8-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        g++ \
+        libpq-dev \
+        libcairo2 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements /tmp/requirements
+
+RUN pip install --upgrade "pip<24.1" && \
+    pip install --requirement /tmp/requirements/local.txt && \
+    apt-get purge -y gcc g++ && \
+    apt-get autoremove -y
+
+COPY . /app
+
+EXPOSE 8000

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,9 +6,11 @@ pipeline {
       namespace = "${env.branchname == 'develop' ? 'uniforme-dev' : env.branchname == 'homolog' ? 'uniforme-hom' : env.branchname == 'homolog-r2' ? 'uniforme-hom2' : 'sme-uniforme' }"
     }
 
-    agent {
-      node { label 'AGENT-NODES' }
-    }
+    agent { kubernetes { 
+              label 'builder'
+              defaultContainer 'builder'
+            }
+          }
 
     options {
       buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '5'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ pipeline {
       branchname =  env.BRANCH_NAME.toLowerCase()
       kubeconfig = getKubeconf(env.branchname)
       registryCredential = 'jenkins_registry'
+      namespace = "${env.branchname == 'develop' ? 'uniforme-dev' : env.branchname == 'homolog' ? 'uniforme-hom' : env.branchname == 'homolog-r2' ? 'uniforme-hom2' : 'sme-uniforme' }"
     }
 
     agent {
@@ -59,7 +60,7 @@ pipeline {
                     withCredentials([file(credentialsId: "${kubeconfig}", variable: 'config')]){
 			    sh('if [ -f '+"$home"+'/.kube/config ];then rm -f '+"$home"+'/.kube/config; fi')
                             sh('cp $config '+"$home"+'/.kube/config')
-                            sh 'kubectl -n sme-uniforme rollout restart deploy'
+                            sh 'kubectl -n ${namespace} rollout restart deploy'
                             sh('if [ -f '+"$home"+'/.kube/config ];then rm -f '+"$home"+'/.kube/config; fi')
                     }
                 }
@@ -90,7 +91,7 @@ def sendTelegram(message) {
 def getKubeconf(branchName) {
     if("main".equals(branchName)) { return "config_prd"; }
     else if ("master".equals(branchName)) { return "config_prd"; }
-    else if ("homolog".equals(branchName)) { return "config_hom"; }
-    else if ("release".equals(branchName)) { return "config_hom"; }
-    else if ("develop".equals(branchName)) { return "config_dev"; }
+    else if ("homolog".equals(branchName)) { return "config_release"; }
+    else if ("release".equals(branchName)) { return "config_release"; }
+    else if ("develop".equals(branchName)) { return "config_release"; }
 }

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,106 @@
+x-app-base: &app-base
+  image: sme-portaluniforme-backend-dev:local
+  build:
+    context: .
+    dockerfile: Dockerfile.dev
+  env_file:
+    - .env
+  environment:
+    POSTGRES_HOST: db
+    POSTGRES_PORT: 5432
+    REDIS_LOCATION: redis://redis:6379/1
+    SERVER_NAME: http://localhost:${BACKEND_PORT:-8000}
+  volumes:
+    - .:/app
+  depends_on:
+    db:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+
+services:
+  web:
+    <<: *app-base
+    command: >
+      sh -c "
+      python manage.py check &&
+      python manage.py migrate &&
+      exec python manage.py runserver 0.0.0.0:8000
+      "
+    ports:
+      - "${BACKEND_PORT:-8000}:8000"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/docs/', timeout=5)"
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  celery-worker:
+    <<: *app-base
+    command: celery -A config worker --loglevel=info
+    depends_on:
+      web:
+        condition: service_healthy
+
+  celery-beat:
+    <<: *app-base
+    command: celery -A config beat --loglevel=info --scheduler django_celery_beat.schedulers:DatabaseScheduler
+    depends_on:
+      web:
+        condition: service_healthy
+
+  db:
+    image: postgres:11.2-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-admin}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-12345qw}
+      POSTGRES_DB: ${POSTGRES_DB:-uniformes}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-12345qw}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U ${POSTGRES_USER:-admin} -d ${POSTGRES_DB:-uniformes}
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:5.0.0-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    ports:
+      - "${REDIS_HOST_PORT:-6379}:6379"
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - ping
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  pgadmin4:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-matheus.jesus@spassu.com.br}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-adminadmin}
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    ports:
+      - "${PGADMIN_PORT:-9090}:80"
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  redis_data:
+  pgadmin_data:

--- a/sme_uniforme_apps/proponentes/admin.py
+++ b/sme_uniforme_apps/proponentes/admin.py
@@ -1,4 +1,3 @@
-import csv
 from io import BytesIO
 
 from django.contrib import admin
@@ -12,7 +11,7 @@ from openpyxl.writer.excel import save_virtual_workbook
 
 from .models import (Anexo, ListaNegra, Loja, OfertaDeUniforme, Proponente,
                      TipoDocumento)
-from .models.forms import AnexoForm
+from .models.forms import AnexoForm, LojaAdminForm, TipoDocumentoAdminForm
 from .services import (atualiza_coordenadas, cnpj_esta_bloqueado,
                        muda_status_de_proponentes, cria_usuario_proponentes_existentes, envia_email_pendencias)
 
@@ -23,7 +22,9 @@ class UniformesFornecidosInLine(admin.TabularInline):
 
 
 class LojasInLine(admin.StackedInline):
+    form = LojaAdminForm
     model = Loja
+    exclude = ('comprovante_endereco',)
     extra = 1  # Quantidade de linhas que serão exibidas.
 
 
@@ -245,6 +246,9 @@ class ListaNegraAdmin(admin.ModelAdmin):
 
 @admin.register(Loja)
 class LojaAdmin(admin.ModelAdmin):
+    form = LojaAdminForm
+    exclude = ('comprovante_endereco',)
+
     @staticmethod
     def protocolo(loja):
         return loja.proponente.protocolo
@@ -265,6 +269,8 @@ class LojaAdmin(admin.ModelAdmin):
 
 @admin.register(TipoDocumento)
 class TipoDocumentoAdmin(admin.ModelAdmin):
+    form = TipoDocumentoAdminForm
+
     def inverte_visivel(self, request, queryset):
         for tipo_documento in queryset.all():
             tipo_documento.visivel = not tipo_documento.visivel
@@ -283,8 +289,8 @@ class TipoDocumentoAdmin(admin.ModelAdmin):
 
     inverte_obrigatorio.short_description = "Inverter o parâmetro 'obrigatório' "
 
-    list_display = ('nome', 'obrigatorio', 'visivel', 'tem_data_validade', 'obrigatorio_sme')
+    list_display = ('identificador', 'nome', 'obrigatorio', 'visivel', 'tem_data_validade', 'obrigatorio_sme')
     ordering = ('nome',)
-    search_fields = ('nome',)
+    search_fields = ('identificador', 'nome')
     list_filter = ('obrigatorio', 'visivel')
     actions = ['inverte_visivel', 'inverte_obrigatorio']

--- a/sme_uniforme_apps/proponentes/admin.py
+++ b/sme_uniforme_apps/proponentes/admin.py
@@ -4,7 +4,10 @@ from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
 from django.db.models import Count
 from django.http import HttpResponse
+from django.utils import timezone
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+from django.utils.text import slugify
 from django.contrib import messages
 from openpyxl import Workbook
 from openpyxl.writer.excel import save_virtual_workbook
@@ -31,7 +34,115 @@ class LojasInLine(admin.StackedInline):
 class AnexosInLine(admin.TabularInline):
     form = AnexoForm
     model = Anexo
-    extra = 1  # Quantidade de linhas que serão exibidas.
+    extra = 0
+    fields = (
+        'tipo_documento',
+        'arquivo',
+        'data_validade',
+        'status_ia_info',
+        'justificativa_ia_info',
+        'status',
+        'justificativa',
+        'ultima_alteracao_admin_info',
+    )
+    readonly_fields = (
+        'status_ia_info',
+        'justificativa_ia_info',
+        'ultima_alteracao_admin_info',
+    )
+
+    class Media:
+        css = {'all': ('proponentes/css/anexos-inline.css',)}
+        js = ()
+
+    @staticmethod
+    def _nome_usuario(usuario):
+        nome_completo = ''
+        if hasattr(usuario, 'get_full_name'):
+            nome_completo = usuario.get_full_name().strip()
+
+        return nome_completo or getattr(usuario, 'email', '') or str(usuario)
+
+    def _resolve_ultima_alteracao(self, obj):
+        usuario = obj.ultima_alteracao_admin_por
+        data = obj.ultima_alteracao_admin_em
+
+        if usuario and data:
+            return usuario, data
+
+        historico = (
+            obj.historico.exclude(actor=None)
+            .select_related('actor')
+            .order_by('-timestamp')
+            .first()
+        )
+        if historico:
+            return historico.actor, historico.timestamp
+
+        return None, None
+
+    def status_ia_info(self, obj):
+        status_ia = obj.status_ia if obj and obj.status_ia else ''
+        status_ia_exibicao = (
+            Anexo.STATUS_NOMES.get(status_ia, status_ia)
+            if status_ia
+            else 'Sem análise de IA.'
+        )
+        classe = 'sem-analise'
+        if status_ia:
+            classe = slugify(status_ia).replace('_', '-') or 'status-ia'
+
+        return format_html(
+            '<span class="anexo-status-ia anexo-status-ia-{}">{}</span>',
+            classe,
+            status_ia_exibicao,
+        )
+
+    status_ia_info.short_description = 'Status IA'
+
+    def justificativa_ia_info(self, obj):
+        justificativa_ia = obj.justificativa_ia if obj and obj.justificativa_ia else ''
+        justificativa_data = justificativa_ia
+
+        if not justificativa_ia:
+            return format_html(
+                '<div class="anexo-ia-justificativa anexo-ia-justificativa-vazia" data-justificativa-ia=""></div>'
+            )
+
+        resumo = justificativa_ia
+        if len(resumo) > 42:
+            resumo = '{}...'.format(resumo[:42])
+
+        return format_html(
+            (
+                '<details class="anexo-ia-detalhe">'
+                '<summary title="{}">{}</summary>'
+                '<div class="anexo-ia-justificativa" data-justificativa-ia="{}">{}</div>'
+                '</details>'
+            ),
+            justificativa_ia,
+            resumo,
+            justificativa_data,
+            justificativa_ia,
+        )
+
+    justificativa_ia_info.short_description = 'Justificativa IA'
+
+    def ultima_alteracao_admin_info(self, obj):
+        if not obj or not obj.pk:
+            return 'Nenhuma alteração registrada.'
+
+        usuario, data = self._resolve_ultima_alteracao(obj)
+        if not usuario or not data:
+            return 'Nenhuma alteração registrada.'
+
+        return format_html(
+            '<div class="anexo-auditoria"><strong>{}</strong><span>{}</span></div>',
+            self._nome_usuario(usuario),
+            timezone.localtime(data).strftime('%d/%m/%Y'),
+        )
+
+    ultima_alteracao_admin_info.short_description = 'Auditoria'
 
 
 class ExportXlsxMixin:
@@ -201,6 +312,23 @@ class ProponenteAdmin(admin.ModelAdmin, ExportXlsxMixin):
             if 'cria_usuario_proponente_sem_usuario' in actions:
                 del actions['cria_usuario_proponente_sem_usuario']
         return actions
+
+    def save_formset(self, request, form, formset, change):
+        if formset.model is not Anexo:
+            return super().save_formset(request, form, formset, change)
+
+        instances = formset.save(commit=False)
+
+        for deleted_object in formset.deleted_objects:
+            deleted_object.delete()
+
+        for instance in instances:
+            instance.copiar_justificativa_ia_para_admin()
+            instance.ultima_alteracao_admin_por = request.user
+            instance.ultima_alteracao_admin_em = timezone.now()
+            instance.save()
+
+        formset.save_m2m()
 
     actions = [
         'verifica_bloqueio_cnpj',

--- a/sme_uniforme_apps/proponentes/api/serializers/anexo_serializer.py
+++ b/sme_uniforme_apps/proponentes/api/serializers/anexo_serializer.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 
 from .tipo_documento_serializer import TipoDocumentoSerializer
 from ...models import Anexo, Proponente
+from ...upload_validation import PDF_EXTENSIONS, validate_upload_extension
 
 log = logging.getLogger(__name__)
 
@@ -20,6 +21,14 @@ class AnexoSerializer(ModelSerializer):
 
 class AnexoCreateSerializer(serializers.ModelSerializer):
     proponente = serializers.UUIDField()
+
+    def validate_arquivo(self, value):
+        try:
+            validate_upload_extension(value, PDF_EXTENSIONS, 'Envie o documento do proponente em PDF.')
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc))
+
+        return value
 
     def create(self, validated_data):
         log.info("Criando anexo!")
@@ -44,3 +53,9 @@ class AnexoCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Anexo
         exclude = ('id',)
+        extra_kwargs = {
+            'arquivo': {
+                'label': 'Documento do proponente',
+                'help_text': 'Envie apenas arquivos PDF.',
+            }
+        }

--- a/sme_uniforme_apps/proponentes/api/serializers/anexo_serializer.py
+++ b/sme_uniforme_apps/proponentes/api/serializers/anexo_serializer.py
@@ -16,7 +16,18 @@ class AnexoSerializer(ModelSerializer):
 
     class Meta:
         model = Anexo
-        fields = '__all__'
+        fields = (
+            "id",
+            "criado_em",
+            "alterado_em",
+            "uuid",
+            "proponente",
+            "arquivo",
+            "data_validade",
+            "status",
+            "justificativa",
+            "tipo_documento",
+        )
 
 
 class AnexoCreateSerializer(serializers.ModelSerializer):
@@ -52,7 +63,13 @@ class AnexoCreateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Anexo
-        exclude = ('id',)
+        exclude = (
+            "id",
+            "status_ia",
+            "justificativa_ia",
+            "ultima_alteracao_admin_por",
+            "ultima_alteracao_admin_em",
+        )
         extra_kwargs = {
             'arquivo': {
                 'label': 'Documento do proponente',

--- a/sme_uniforme_apps/proponentes/api/serializers/loja_serializer.py
+++ b/sme_uniforme_apps/proponentes/api/serializers/loja_serializer.py
@@ -1,9 +1,12 @@
 import environ
 
 from rest_framework import serializers
-from config.settings.base import MEDIA_URL
 from ...models import Loja
-
+from ...upload_validation import (
+    IMAGE_EXTENSIONS,
+    PDF_EXTENSIONS,
+    validate_upload_extension,
+)
 
 env = environ.Env()
 SERVER_NAME = f'{env("SERVER_NAME")}'
@@ -28,15 +31,72 @@ class LojaSerializer(serializers.ModelSerializer):
 
 class LojaCreateSerializer(serializers.ModelSerializer):
 
+    def validate_foto_fachada(self, value):
+        if not value:
+            return value
+
+        try:
+            validate_upload_extension(value, IMAGE_EXTENSIONS, 'Envie a foto da fachada em JPG, JPEG ou PNG.')
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc))
+
+        return value
+
+    def validate_comprovante_endereco(self, value):
+        if not value:
+            return value
+
+        try:
+            validate_upload_extension(
+                value,
+                PDF_EXTENSIONS,
+                'Envie o comprovante de endereço do ponto de venda em PDF.',
+            )
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc))
+
+        return value
+
     class Meta:
         model = Loja
         exclude = ('id', 'proponente')
+        extra_kwargs = {
+            'comprovante_endereco': {
+                'label': 'Comprovante de endereço do ponto de venda',
+                'help_text': 'Campo opcional. Se enviado, deve estar em PDF.',
+                'required': False,
+                'allow_null': True,
+            },
+            'foto_fachada': {
+                'label': 'Foto da fachada da loja',
+                'help_text': 'Envie apenas arquivos JPG, JPEG ou PNG.',
+                'required': False,
+                'allow_null': True,
+            },
+        }
 
 
 class LojaUpdateFachadaSerializer(serializers.ModelSerializer):
     uuid = serializers.UUIDField(read_only=True)
     nome_fantasia = serializers.CharField(read_only=True)
 
+    def validate_foto_fachada(self, value):
+        if not value:
+            return value
+
+        try:
+            validate_upload_extension(value, IMAGE_EXTENSIONS, 'Envie a foto da fachada em JPG, JPEG ou PNG.')
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc))
+
+        return value
+
     class Meta:
         model = Loja
         fields = ('uuid', 'nome_fantasia', 'foto_fachada',)
+        extra_kwargs = {
+            'foto_fachada': {
+                'label': 'Foto da fachada da loja',
+                'help_text': 'Envie apenas arquivos JPG, JPEG ou PNG.',
+            }
+        }

--- a/sme_uniforme_apps/proponentes/api/serializers/tipo_documento_serializer.py
+++ b/sme_uniforme_apps/proponentes/api/serializers/tipo_documento_serializer.py
@@ -6,4 +6,4 @@ from ...models import TipoDocumento
 class TipoDocumentoSerializer(serializers.ModelSerializer):
     class Meta:
         model = TipoDocumento
-        fields = ('id', 'nome', 'obrigatorio', 'tem_data_validade', 'obrigatorio_sme')
+        fields = ('id', 'identificador', 'nome', 'obrigatorio', 'tem_data_validade', 'obrigatorio_sme')

--- a/sme_uniforme_apps/proponentes/api/viewsets/proponentes_viewset.py
+++ b/sme_uniforme_apps/proponentes/api/viewsets/proponentes_viewset.py
@@ -13,6 +13,7 @@ from sme_uniforme_apps.core.models import Uniforme
 from sme_uniforme_apps.proponentes.api.serializers.loja_serializer import LojaCreateSerializer
 from sme_uniforme_apps.proponentes.models import OfertaDeUniforme
 from sme_uniforme_apps.proponentes.services import atualiza_coordenadas_lojas
+from sme_uniforme_apps.proponentes.upload_validation import PDF_EXTENSIONS, validate_upload_extension
 from ..serializers.proponente_serializer import ProponenteSerializer, ProponenteCreateSerializer
 
 from ...models import Proponente, ListaNegra, Loja
@@ -87,8 +88,18 @@ class ProponentesViewSet(mixins.CreateModelMixin,
                 loja_obj.nome_fantasia = loja.get('nome_fantasia')
                 loja_obj.telefone = loja.get('telefone')
                 loja_obj.site = loja.get('site')
-                if loja.get('comprovante_endereco') is not None:
-                    file = base64ToFile(loja.get('comprovante_endereco'))
+                comprovante_endereco = loja.get('comprovante_endereco')
+                if comprovante_endereco:
+                    try:
+                        validate_upload_extension(
+                            comprovante_endereco,
+                            PDF_EXTENSIONS,
+                            'Envie o comprovante de endereço do ponto de venda em PDF.',
+                        )
+                    except ValueError as exc:
+                        raise ValidationError(str(exc))
+
+                    file = base64ToFile(comprovante_endereco)
                     loja_obj.comprovante_endereco.save('comprovante_endereco_loja.' + file['ext'], file['data'])
                 loja_obj.save()
             else:
@@ -97,10 +108,20 @@ class ProponentesViewSet(mixins.CreateModelMixin,
                                     'uf', 'firstName']
                 for attr in atributos_extras:
                     loja.pop(attr, '')
-                comprovante = loja.pop('comprovante_endereco', '')    
+                comprovante = loja.pop('comprovante_endereco', None)
                 loja_object = LojaCreateSerializer().create(loja)
-                file = base64ToFile(comprovante)
-                loja_object.comprovante_endereco.save('comprovante_endereco_loja.' + file['ext'], file['data'])
+                if comprovante:
+                    try:
+                        validate_upload_extension(
+                            comprovante,
+                            PDF_EXTENSIONS,
+                            'Envie o comprovante de endereço do ponto de venda em PDF.',
+                        )
+                    except ValueError as exc:
+                        raise ValidationError(str(exc))
+
+                    file = base64ToFile(comprovante)
+                    loja_object.comprovante_endereco.save('comprovante_endereco_loja.' + file['ext'], file['data'])
                 proponente.lojas.add(loja_object)
                 lojas_ids.append(loja_object.id)
         atualiza_coordenadas_lojas(proponente.lojas)

--- a/sme_uniforme_apps/proponentes/api/viewsets/tipos_documento_viewset.py
+++ b/sme_uniforme_apps/proponentes/api/viewsets/tipos_documento_viewset.py
@@ -13,8 +13,8 @@ class TiposDocumentoViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = TipoDocumentoSerializer
     permission_classes = [AllowAny]
     filter_backends = (filters.DjangoFilterBackend, SearchFilter, OrderingFilter)
-    ordering_fields = ('nome',)
-    search_fields = ('uuid', 'id', 'nome')
+    ordering_fields = ('nome', 'identificador')
+    search_fields = ('uuid', 'id', 'nome', 'identificador')
     filter_fields = ('obrigatorio',)
 
     def get_queryset(self):

--- a/sme_uniforme_apps/proponentes/migrations/0032_tipodocumento_identificador.py
+++ b/sme_uniforme_apps/proponentes/migrations/0032_tipodocumento_identificador.py
@@ -1,0 +1,30 @@
+from django.core.validators import RegexValidator
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("proponentes", "0031_auto_20220215_1457"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="tipodocumento",
+            name="identificador",
+            field=models.CharField(
+                blank=True,
+                help_text="Use apenas letras, números, hífen e underscore.",
+                max_length=100,
+                null=True,
+                unique=True,
+                validators=[
+                    RegexValidator(
+                        message="Use apenas letras, números, hífen e underscore.",
+                        regex="^[0-9A-Za-z_-]+$",
+                    )
+                ],
+                verbose_name="Identificador",
+            ),
+        ),
+    ]

--- a/sme_uniforme_apps/proponentes/migrations/0033_anexo_campos_ia_e_auditoria.py
+++ b/sme_uniforme_apps/proponentes/migrations/0033_anexo_campos_ia_e_auditoria.py
@@ -1,0 +1,76 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("proponentes", "0032_tipodocumento_identificador"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="anexo",
+            name="justificativa_ia",
+            field=models.TextField(
+                blank=True, null=True, verbose_name="Justificativa IA"
+            ),
+        ),
+        migrations.AddField(
+            model_name="anexo",
+            name="status_ia",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("APROVADO", "Aprovado"),
+                    ("REPROVADO", "Reprovado"),
+                    ("PENDENTE", "Pendente"),
+                    ("VENCIDO", "Vencido"),
+                ],
+                max_length=15,
+                null=True,
+                verbose_name="Status IA",
+            ),
+        ),
+        migrations.AddField(
+            model_name="anexo",
+            name="ultima_alteracao_admin_em",
+            field=models.DateTimeField(blank=True, editable=False, null=True),
+        ),
+        migrations.AddField(
+            model_name="anexo",
+            name="ultima_alteracao_admin_por",
+            field=models.ForeignKey(
+                blank=True,
+                editable=False,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="anexos_alterados_no_admin",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="anexo",
+            name="justificativa",
+            field=models.TextField(
+                blank=True, null=True, verbose_name="Justificativa Admin"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="anexo",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("APROVADO", "Aprovado"),
+                    ("REPROVADO", "Reprovado"),
+                    ("PENDENTE", "Pendente"),
+                    ("VENCIDO", "Vencido"),
+                ],
+                default="PENDENTE",
+                max_length=15,
+                verbose_name="Status Admin",
+            ),
+        ),
+    ]

--- a/sme_uniforme_apps/proponentes/migrations/0034_altera_status_ia_aberto.py
+++ b/sme_uniforme_apps/proponentes/migrations/0034_altera_status_ia_aberto.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("proponentes", "0033_anexo_campos_ia_e_auditoria"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="anexo",
+            name="status_ia",
+            field=models.CharField(
+                blank=True, max_length=255, null=True, verbose_name="Status IA"
+            ),
+        ),
+    ]

--- a/sme_uniforme_apps/proponentes/models/anexo.py
+++ b/sme_uniforme_apps/proponentes/models/anexo.py
@@ -1,5 +1,6 @@
 from auditlog.models import AuditlogHistoryField
 from auditlog.registry import auditlog
+from django.conf import settings
 from django.db import models
 
 from sme_uniforme_apps.core.models_abstracts import ModeloBase
@@ -27,6 +28,7 @@ class Anexo(ModeloBase):
         (STATUS_PENDENTE, STATUS_NOMES[STATUS_PENDENTE]),
         (STATUS_VENCIDO, STATUS_NOMES[STATUS_VENCIDO]),
     )
+    STATUS_COM_COPIA_DA_IA = (STATUS_REPROVADO, STATUS_VENCIDO)
 
     historico = AuditlogHistoryField()
 
@@ -37,13 +39,28 @@ class Anexo(ModeloBase):
     data_validade = models.DateField(null=True, blank=True)
 
     status = models.CharField(
-        'status',
+        'Status Admin',
         max_length=15,
         choices=STATUS_CHOICES,
         default=STATUS_PENDENTE
     )
 
-    justificativa = models.TextField('Justificativa', blank=True, null=True)
+    justificativa = models.TextField('Justificativa Admin', blank=True, null=True)
+
+    status_ia = models.CharField('Status IA', max_length=255, blank=True, null=True)
+
+    justificativa_ia = models.TextField('Justificativa IA', blank=True, null=True)
+
+    ultima_alteracao_admin_por = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        editable=False,
+        related_name='anexos_alterados_no_admin'
+    )
+
+    ultima_alteracao_admin_em = models.DateTimeField(blank=True, null=True, editable=False)
 
     tipo_documento = models.ForeignKey(
         TipoDocumento,
@@ -63,6 +80,14 @@ class Anexo(ModeloBase):
             "data_validade": self.data_validade,
             "uuid": self.uuid
         }
+
+    def copiar_justificativa_ia_para_admin(self, sobrescrever=False):
+        if (
+            self.status in self.STATUS_COM_COPIA_DA_IA
+            and self.justificativa_ia
+            and (sobrescrever or not self.justificativa)
+        ):
+            self.justificativa = self.justificativa_ia
 
     class Meta:
         verbose_name = "Anexo"

--- a/sme_uniforme_apps/proponentes/models/forms.py
+++ b/sme_uniforme_apps/proponentes/models/forms.py
@@ -16,6 +16,38 @@ class AnexoForm(forms.ModelForm):
         self.fields["tipo_documento"].required = True
         self.fields["arquivo"].label = "Documento do proponente"
         self.fields["arquivo"].help_text = "Envie apenas arquivos PDF."
+        self.fields["tipo_documento"].widget.attrs["style"] = "width: 220px;"
+        self.fields["tipo_documento"].widget.attrs[
+            "onchange"
+        ] = "this.title=this.options[this.selectedIndex] ? this.options[this.selectedIndex].text : '';"
+        if self.instance and self.instance.tipo_documento_id:
+            self.fields["tipo_documento"].widget.attrs[
+                "title"
+            ] = self.instance.tipo_documento.nome
+        self.fields["status"].label = "Status Admin"
+        self.fields["justificativa"].label = "Justificativa Admin"
+        self.fields["status"].initial = self.instance.status or Anexo.STATUS_PENDENTE
+        self.fields["status"].widget.attrs["style"] = "width: 140px;"
+        self.fields["status"].widget.attrs["onchange"] = (
+            "var inline=this.closest('.dynamic-anexos');"
+            "var justificativa=inline&&inline.querySelector('textarea[id$=\"-justificativa\"]');"
+            "var justificativaIA=inline&&inline.querySelector('.anexo-ia-justificativa');"
+            "if((this.value==='REPROVADO'||this.value==='VENCIDO')&&justificativa&&!justificativa.value.trim()&&justificativaIA){"
+            "justificativa.value=(justificativaIA.getAttribute('data-justificativa-ia')||'').trim();"
+            "}"
+        )
+        self.fields["justificativa"].widget.attrs["rows"] = 3
+        self.fields["justificativa"].widget.attrs["style"] = "width: 340px;"
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        self.instance.status = cleaned_data.get("status")
+        self.instance.justificativa = cleaned_data.get("justificativa")
+        self.instance.copiar_justificativa_ia_para_admin()
+        cleaned_data["justificativa"] = self.instance.justificativa
+
+        return cleaned_data
 
     def clean_arquivo(self):
         arquivo = self.cleaned_data.get("arquivo")
@@ -36,7 +68,12 @@ class AnexoForm(forms.ModelForm):
 
     class Meta:
         model = Anexo
-        fields = '__all__'
+        exclude = (
+            "status_ia",
+            "justificativa_ia",
+            "ultima_alteracao_admin_por",
+            "ultima_alteracao_admin_em",
+        )
 
 
 class LojaAdminForm(forms.ModelForm):

--- a/sme_uniforme_apps/proponentes/models/forms.py
+++ b/sme_uniforme_apps/proponentes/models/forms.py
@@ -1,6 +1,11 @@
 from django import forms
 
-from sme_uniforme_apps.proponentes.models import Anexo
+from sme_uniforme_apps.proponentes.models import Anexo, Loja, TipoDocumento
+from sme_uniforme_apps.proponentes.upload_validation import (
+    IMAGE_EXTENSIONS,
+    PDF_EXTENSIONS,
+    validate_upload_extension,
+)
 
 
 class AnexoForm(forms.ModelForm):
@@ -8,8 +13,92 @@ class AnexoForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(AnexoForm, self).__init__(*args, **kwargs)
 
-        self.fields['tipo_documento'].required = True
+        self.fields["tipo_documento"].required = True
+        self.fields["arquivo"].label = "Documento do proponente"
+        self.fields["arquivo"].help_text = "Envie apenas arquivos PDF."
+
+    def clean_arquivo(self):
+        arquivo = self.cleaned_data.get("arquivo")
+
+        if not arquivo or "arquivo" not in self.changed_data:
+            return arquivo
+
+        try:
+            validate_upload_extension(
+                arquivo,
+                PDF_EXTENSIONS,
+                "Envie o documento do proponente em PDF.",
+            )
+        except ValueError as exc:
+            raise forms.ValidationError(str(exc))
+
+        return arquivo
 
     class Meta:
         model = Anexo
         fields = '__all__'
+
+
+class LojaAdminForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super(LojaAdminForm, self).__init__(*args, **kwargs)
+
+        self.fields["foto_fachada"].label = "Foto da fachada da loja"
+        self.fields["foto_fachada"].help_text = (
+            "Envie apenas arquivos JPG, JPEG ou PNG."
+        )
+
+    def clean_foto_fachada(self):
+        foto_fachada = self.cleaned_data.get("foto_fachada")
+
+        if not foto_fachada or "foto_fachada" not in self.changed_data:
+            return foto_fachada
+
+        try:
+            validate_upload_extension(
+                foto_fachada,
+                IMAGE_EXTENSIONS,
+                "Envie a foto da fachada em JPG, JPEG ou PNG.",
+            )
+        except ValueError as exc:
+            raise forms.ValidationError(str(exc))
+
+        return foto_fachada
+
+    class Meta:
+        model = Loja
+        fields = "__all__"
+
+
+class TipoDocumentoAdminForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super(TipoDocumentoAdminForm, self).__init__(*args, **kwargs)
+
+        self.fields["identificador"].required = True
+        self.fields["identificador"].error_messages[
+            "required"
+        ] = "Informe o identificador alfanumérico."
+
+    def clean_identificador(self):
+        identificador = (self.cleaned_data.get("identificador") or "").strip() or None
+
+        if not identificador:
+            raise forms.ValidationError("Informe o identificador alfanumérico.")
+
+        if (
+            identificador
+            and TipoDocumento.objects.exclude(pk=self.instance.pk)
+            .filter(identificador=identificador)
+            .exists()
+        ):
+            raise forms.ValidationError(
+                "Já existe um tipo de documento com este identificador."
+            )
+
+        return identificador
+
+    class Meta:
+        model = TipoDocumento
+        fields = "__all__"

--- a/sme_uniforme_apps/proponentes/models/tipo_documento.py
+++ b/sme_uniforme_apps/proponentes/models/tipo_documento.py
@@ -1,9 +1,24 @@
+from django.core.validators import RegexValidator
 from django.db import models
 
 from sme_uniforme_apps.core.models_abstracts import ModeloBase
 
 
 class TipoDocumento(ModeloBase):
+    identificador = models.CharField(
+        "Identificador",
+        max_length=100,
+        unique=True,
+        blank=True,
+        null=True,
+        help_text="Use apenas letras, números, hífen e underscore.",
+        validators=[
+            RegexValidator(
+                regex=r"^[0-9A-Za-z_-]+$",
+                message="Use apenas letras, números, hífen e underscore.",
+            )
+        ],
+    )
     nome = models.TextField('Tipo de documento', unique=True)
     obrigatorio = models.BooleanField(default=True)
     visivel = models.BooleanField(default=True)

--- a/sme_uniforme_apps/proponentes/static/proponentes/css/anexos-inline.css
+++ b/sme_uniforme_apps/proponentes/static/proponentes/css/anexos-inline.css
@@ -1,0 +1,174 @@
+#anexos-group table {
+    table-layout: fixed;
+}
+
+#anexos-group td.original,
+#anexos-group td.field-tipo_documento,
+#anexos-group td.field-arquivo,
+#anexos-group td.field-data_validade,
+#anexos-group td.field-status_ia_info,
+#anexos-group td.field-justificativa_ia_info,
+#anexos-group td.field-status,
+#anexos-group td.field-justificativa,
+#anexos-group td.field-ultima_alteracao_admin_info,
+#anexos-group th.original,
+#anexos-group th.column-tipo_documento,
+#anexos-group th.column-arquivo,
+#anexos-group th.column-data_validade,
+#anexos-group th.column-status_ia_info,
+#anexos-group th.column-justificativa_ia_info,
+#anexos-group th.column-status,
+#anexos-group th.column-justificativa,
+#anexos-group th.column-ultima_alteracao_admin_info {
+    vertical-align: top !important;
+}
+
+#anexos-group td.original p,
+#anexos-group td.field-arquivo .file-upload,
+#anexos-group td.field-data_validade p,
+#anexos-group td.field-justificativa_ia_info details,
+#anexos-group td.field-tipo_documento .related-widget-wrapper {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+#anexos-group td.field-tipo_documento,
+#anexos-group th.column-tipo_documento {
+    width: 220px;
+}
+
+#anexos-group td.field-arquivo,
+#anexos-group th.column-arquivo {
+    width: 180px;
+}
+
+#anexos-group td.field-arquivo {
+    padding-top: 2px !important;
+}
+
+#anexos-group td.field-data_validade,
+#anexos-group th.column-data_validade {
+    width: 105px;
+}
+
+#anexos-group td.field-status_ia_info,
+#anexos-group th.column-status_ia_info {
+    width: 110px;
+}
+
+#anexos-group td.field-justificativa_ia_info,
+#anexos-group th.column-justificativa_ia_info {
+    width: 200px;
+}
+
+#anexos-group td.field-status,
+#anexos-group th.column-status {
+    width: 145px;
+}
+
+#anexos-group td.field-justificativa,
+#anexos-group th.column-justificativa {
+    width: 360px;
+}
+
+#anexos-group td.field-ultima_alteracao_admin_info,
+#anexos-group th.column-ultima_alteracao_admin_info {
+    width: 170px;
+}
+
+#anexos-group td.field-tipo_documento select,
+#anexos-group td.field-arquivo input[type="file"],
+#anexos-group td.field-status select,
+#anexos-group td.field-justificativa textarea,
+#anexos-group td.field-data_validade input[type="text"] {
+    max-width: 100%;
+}
+
+#anexos-group td.field-tipo_documento .related-widget-wrapper {
+    display: inline-flex;
+    align-items: flex-start;
+    gap: 4px;
+    max-width: 220px;
+}
+
+#anexos-group td.field-tipo_documento select {
+    width: 220px !important;
+    max-width: 220px !important;
+}
+
+#anexos-group td.field-arquivo .file-upload,
+#anexos-group td.field-status_ia_info .readonly,
+#anexos-group td.field-justificativa_ia_info .readonly,
+#anexos-group td.field-ultima_alteracao_admin_info .readonly {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+}
+
+#anexos-group td.field-arquivo .file-upload {
+    flex-direction: column;
+}
+
+#anexos-group td.field-status select,
+#anexos-group td.field-justificativa textarea,
+#anexos-group td.field-data_validade p {
+    margin-top: 0;
+}
+
+#anexos-group .readonly,
+#anexos-group .anexo-ia-justificativa,
+#anexos-group .anexo-auditoria {
+    white-space: normal;
+    word-break: break-word;
+}
+
+#anexos-group .anexo-status-ia {
+    display: inline-block;
+    padding: 3px 8px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.3;
+    white-space: nowrap;
+}
+
+#anexos-group .anexo-status-ia-aprovado {
+    background: #e7f6eb;
+    color: #22603a;
+}
+
+#anexos-group .anexo-status-ia-reprovado,
+#anexos-group .anexo-status-ia-vencido {
+    background: #fbe9e7;
+    color: #8a2d1d;
+}
+
+#anexos-group .anexo-status-ia-pendente,
+#anexos-group .anexo-status-ia-sem-analise {
+    background: #edf2f7;
+    color: #465a69;
+}
+
+#anexos-group .anexo-ia-detalhe {
+    max-width: 200px;
+}
+
+#anexos-group .anexo-ia-detalhe summary {
+    cursor: pointer;
+    color: #0b57a3;
+}
+
+#anexos-group .anexo-ia-justificativa {
+    margin-top: 6px;
+}
+
+#anexos-group .anexo-ia-justificativa-vazia {
+    min-height: 18px;
+}
+
+#anexos-group .anexo-auditoria {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+}

--- a/sme_uniforme_apps/proponentes/tests/conftest.py
+++ b/sme_uniforme_apps/proponentes/tests/conftest.py
@@ -48,9 +48,9 @@ def loja_fisica(proponente, arquivo):
     )
 
 @pytest.fixture
-def payload_update_fachada_loja(arquivo_anexo_base64):
+def payload_update_fachada_loja(arquivo_fachada_base64):
     return {
-        "foto_fachada": arquivo_anexo_base64,
+        "foto_fachada": arquivo_fachada_base64,
     }
 
 
@@ -104,6 +104,7 @@ def proponente_bloqueado(cnpj_bloqueado, lista_negra):
 def tipo_documento():
     return baker.make(
         'TipoDocumento',
+        identificador='CERTIDAO_NEGATIVA',
         nome='Certidão Negativa',
         obrigatorio=True,
         visivel=True
@@ -114,6 +115,7 @@ def tipo_documento():
 def tipo_documento_nao_obrigatorio():
     return baker.make(
         'TipoDocumento',
+        identificador='CARTA_RECOMENDACAO',
         nome='Carta de Recomendação',
         obrigatorio=False,
     )
@@ -121,7 +123,18 @@ def tipo_documento_nao_obrigatorio():
 
 @pytest.fixture
 def arquivo_anexo_base64():
-    return "data:text/plain/txt;base64,RW5kZXJl528gSVB2NDoJMTAuNDkuMjMuOTANClNlcnZpZG9yZXMgRE5TIElQdjQ6CTEwLjQ5LjE2LjQwCjEwLjQ5LjE2LjQzDQpTdWZpeG8gRE5TIFByaW3hcmlvOgllZHVjYWNhby5pbnRyYW5ldA0KRmFicmljYW50ZToJSW50ZWwNCkRlc2NyaefjbzoJSW50ZWwoUikgRXRoZXJuZXQgQ29ubmVjdGlvbiBJMjE4LUxNDQpWZXJz428gZG8gZHJpdmVyOgkxMi4xMy4xNy40DQpFbmRlcmXnbyBm7XNpY28gKE1BQyk6CTc0LUU2LUUyLUQwLUVDLTNF"
+    return "data:application/pdf;base64,JVBERi0xLjQKJUVPRgo="
+
+
+@pytest.fixture
+def arquivo_fachada_base64():
+    return "data:image/png;base64,iVBORw0KGgo="
+
+
+@pytest.fixture
+def arquivo_txt_base64():
+    return "data:text/plain;base64,Q09OVEVVRE8gVEVTVEU="
+
 
 @pytest.fixture
 def payload_anexo(arquivo_anexo_base64, tipo_documento, proponente):
@@ -219,7 +232,7 @@ def payload_ofertas_de_uniformes_faltando_a_camisa(uniforme_calca, uniforme_teni
 
 
 @pytest.fixture
-def payload_lojas(arquivo_anexo_base64):
+def payload_lojas(arquivo_fachada_base64):
     return [
         {
             "nome_fantasia": "Loja A",
@@ -232,7 +245,7 @@ def payload_lojas(arquivo_anexo_base64):
             "longitude": 0,
             "numero_iptu": "",
             "telefone": "(55) 4344-8765",
-            "foto_fachada": arquivo_anexo_base64
+            "foto_fachada": arquivo_fachada_base64
         },
         {
             "nome_fantasia": "Loja B",
@@ -244,7 +257,7 @@ def payload_lojas(arquivo_anexo_base64):
             "longitude": 0,
             "numero_iptu": "",
             "telefone": "(24) 9988-29105",
-            "foto_fachada": arquivo_anexo_base64
+            "foto_fachada": arquivo_fachada_base64
         }
     ]
 

--- a/sme_uniforme_apps/proponentes/tests/test_anexo/test_admin.py
+++ b/sme_uniforme_apps/proponentes/tests/test_anexo/test_admin.py
@@ -1,0 +1,176 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.forms.models import inlineformset_factory
+from django.test import RequestFactory
+from django.urls import reverse
+from django.utils import timezone
+
+from ...admin import AnexosInLine, ProponenteAdmin
+from ...models import Anexo, Proponente
+from ...models.forms import AnexoForm
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+@pytest.fixture
+def admin_user():
+    usuario = User.objects.create_superuser(email="gestor@teste.com", password="123456")
+    usuario.first_name = "Gestor"
+    usuario.last_name = "Contrato"
+    usuario.save()
+    return usuario
+
+
+@pytest.fixture
+def admin_client_logado(client, admin_user):
+    client.force_login(admin_user)
+    return client
+
+
+def test_tela_admin_do_proponente_exibe_campos_ia_e_admin(admin_client_logado, anexo):
+    response = admin_client_logado.get(
+        reverse("admin:proponentes_proponente_change", args=[anexo.proponente.pk])
+    )
+
+    assert response.status_code == 200
+    conteudo = response.content.decode("utf-8")
+    assert "Status IA" in conteudo
+    assert "Justificativa IA" in conteudo
+    assert "Status Admin" in conteudo
+    assert "Justificativa Admin" in conteudo
+    assert 'name="anexos-0-status"' in conteudo
+    assert 'name="anexos-0-status_ia"' not in conteudo
+    assert 'name="anexos-0-justificativa_ia"' not in conteudo
+    assert "proponentes/js/anexos-inline.js" not in conteudo
+    assert "anexo-ia-justificativa" in conteudo
+    assert "querySelector" in conteudo
+
+
+def test_save_formset_do_admin_copia_justificativa_e_registra_auditoria(
+    admin_user,
+    proponente,
+    anexo,
+):
+    site = AdminSite()
+    model_admin = ProponenteAdmin(Proponente, site)
+    formset_class = inlineformset_factory(
+        Proponente,
+        Anexo,
+        form=AnexoForm,
+        extra=0,
+        can_delete=True,
+    )
+    prefix = formset_class.get_default_prefix()
+    anexo.status_ia = Anexo.STATUS_REPROVADO
+    anexo.justificativa_ia = "Documento divergente segundo a IA."
+    anexo.save(update_fields=["status_ia", "justificativa_ia"])
+    data = {
+        f"{prefix}-TOTAL_FORMS": "1",
+        f"{prefix}-INITIAL_FORMS": "1",
+        f"{prefix}-MIN_NUM_FORMS": "0",
+        f"{prefix}-MAX_NUM_FORMS": "1000",
+        f"{prefix}-0-id": str(anexo.id),
+        f"{prefix}-0-proponente": str(proponente.id),
+        f"{prefix}-0-tipo_documento": str(anexo.tipo_documento_id),
+        f"{prefix}-0-data_validade": "",
+        f"{prefix}-0-status": Anexo.STATUS_REPROVADO,
+        f"{prefix}-0-justificativa": "",
+    }
+    formset = formset_class(data=data, instance=proponente, prefix=prefix)
+
+    assert formset.is_valid(), formset.errors
+
+    request = RequestFactory().post("/")
+    request.user = admin_user
+
+    model_admin.save_formset(request, None, formset, change=True)
+
+    anexo.refresh_from_db()
+
+    assert anexo.justificativa == "Documento divergente segundo a IA."
+    assert anexo.ultima_alteracao_admin_por == admin_user
+    assert anexo.ultima_alteracao_admin_em is not None
+
+
+def test_inline_exibe_informacao_de_auditoria_no_admin(
+    admin_client_logado, admin_user, anexo
+):
+    anexo.ultima_alteracao_admin_por = admin_user
+    anexo.ultima_alteracao_admin_em = timezone.now()
+    anexo.save(
+        update_fields=["ultima_alteracao_admin_por", "ultima_alteracao_admin_em"]
+    )
+
+    response = admin_client_logado.get(
+        reverse("admin:proponentes_proponente_change", args=[anexo.proponente.pk])
+    )
+
+    assert response.status_code == 200
+    conteudo = response.content.decode("utf-8")
+    assert "anexo-auditoria" in conteudo
+    assert "Gestor Contrato" in conteudo
+    assert (
+        timezone.localtime(anexo.ultima_alteracao_admin_em).strftime("%d/%m/%Y")
+        in conteudo
+    )
+
+
+def test_inline_monta_texto_de_auditoria_com_nome_e_data(admin_user, anexo):
+    inline = AnexosInLine(Proponente, AdminSite())
+    anexo.ultima_alteracao_admin_por = admin_user
+    anexo.ultima_alteracao_admin_em = timezone.now()
+
+    texto = inline.ultima_alteracao_admin_info(anexo)
+
+    assert "Gestor Contrato" in texto
+    assert (
+        timezone.localtime(anexo.ultima_alteracao_admin_em).strftime("%d/%m/%Y")
+        in texto
+    )
+
+
+def test_inline_exibe_justificativa_ia_em_bloco_readonly_com_hook_js(anexo):
+    inline = AnexosInLine(Proponente, AdminSite())
+    anexo.status_ia = Anexo.STATUS_REPROVADO
+    anexo.justificativa_ia = "Documento divergente segundo a IA."
+
+    html = inline.justificativa_ia_info(anexo)
+
+    assert "<details" in html
+    assert "Documento divergente segundo a IA." in html
+    assert "anexo-ia-justificativa" in html
+    assert 'data-justificativa-ia="Documento divergente segundo a IA."' in html
+
+
+def test_inline_deixa_justificativa_ia_vazia_quando_nao_ha_texto(anexo):
+    inline = AnexosInLine(Proponente, AdminSite())
+    anexo.justificativa_ia = ""
+
+    html = inline.justificativa_ia_info(anexo)
+
+    assert "Sem justificativa de IA." not in html
+    assert "<details" not in html
+    assert 'data-justificativa-ia=""' in html
+
+
+def test_inline_exibe_status_ia_em_formato_compacto(anexo):
+    inline = AnexosInLine(Proponente, AdminSite())
+    anexo.status_ia = Anexo.STATUS_REPROVADO
+
+    html = inline.status_ia_info(anexo)
+
+    assert "anexo-status-ia" in html
+    assert "Reprovado" in html
+
+
+def test_inline_exibe_status_ia_desconhecido_sem_choices_fixos(anexo):
+    inline = AnexosInLine(Proponente, AdminSite())
+    anexo.status_ia = "EM_ANALISE_EXTERNA_MANUAL"
+
+    html = inline.status_ia_info(anexo)
+
+    assert "EM_ANALISE_EXTERNA_MANUAL" in html
+    assert "anexo-status-ia-em-analise-externa-manual" in html

--- a/sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py
+++ b/sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py
@@ -1,11 +1,23 @@
 import json
 
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework import status
 
+from ...api.serializers.anexo_serializer import AnexoCreateSerializer
+from ...models.forms import AnexoForm
 from ...models.anexo import Anexo
 
 pytestmark = pytest.mark.django_db
+
+
+ARQUIVO_JPG_BASE64 = "data:image/jpg;base64,/9j/4AAQSkZJRgABAQ=="
+ARQUIVO_PNG_BASE64 = "data:image/png;base64,iVBORw0KGgo="
+ARQUIVO_TXT_BASE64 = "data:text/plain;base64,Q09OVEVVRE8gVEVTVEU="
+
+
+def create_uploaded_file(file_name):
+    return SimpleUploadedFile(file_name, b"conteudo_teste")
 
 
 @pytest.fixture
@@ -30,3 +42,58 @@ def test_anexo_api_delete_model(delete):
 
 def test_anexo_api_create_model_not_exists(client, delete):
     assert not Anexo.objects.exists()
+
+
+def test_anexo_form_configura_label_e_help_text():
+    form = AnexoForm()
+
+    assert form.fields["arquivo"].label == "Documento do proponente"
+    assert form.fields["arquivo"].help_text == "Envie apenas arquivos PDF."
+
+
+def test_anexo_create_serializer_configura_label_e_help_text():
+    serializer = AnexoCreateSerializer()
+
+    assert serializer.fields["arquivo"].label == "Documento do proponente"
+    assert serializer.fields["arquivo"].help_text == "Envie apenas arquivos PDF."
+
+
+def test_anexo_form_aceita_pdf(tipo_documento):
+    form = AnexoForm(
+        data={
+            "tipo_documento": tipo_documento.id,
+            "status": Anexo.STATUS_PENDENTE,
+        },
+        files={"arquivo": create_uploaded_file("anexo.pdf")},
+    )
+
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.parametrize("file_name", ["anexo.jpg", "anexo.png", "anexo.txt"])
+def test_anexo_form_rejeita_arquivo_nao_pdf(tipo_documento, file_name):
+    form = AnexoForm(
+        data={
+            "tipo_documento": tipo_documento.id,
+            "status": Anexo.STATUS_PENDENTE,
+        },
+        files={"arquivo": create_uploaded_file(file_name)},
+    )
+
+    assert not form.is_valid()
+    assert form.errors["arquivo"] == ["Envie o documento do proponente em PDF."]
+
+
+@pytest.mark.parametrize(
+    "arquivo_invalido", [ARQUIVO_JPG_BASE64, ARQUIVO_PNG_BASE64, ARQUIVO_TXT_BASE64]
+)
+def test_anexo_api_rejeita_arquivo_nao_pdf(client, payload_anexo, arquivo_invalido):
+    payload_anexo["arquivo"] = arquivo_invalido
+
+    response = client.post(
+        "/anexos/", data=json.dumps(payload_anexo), content_type="application/json"
+    )
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result["arquivo"] == ["Envie o documento do proponente em PDF."]

--- a/sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py
+++ b/sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py
@@ -49,6 +49,22 @@ def test_anexo_form_configura_label_e_help_text():
 
     assert form.fields["arquivo"].label == "Documento do proponente"
     assert form.fields["arquivo"].help_text == "Envie apenas arquivos PDF."
+    assert form.fields["status"].label == "Status Admin"
+    assert form.fields["justificativa"].label == "Justificativa Admin"
+    assert form.fields["status"].initial == Anexo.STATUS_PENDENTE
+    assert form.fields["tipo_documento"].widget.attrs["style"] == "width: 220px;"
+    assert form.fields["justificativa"].widget.attrs["style"] == "width: 340px;"
+    assert "status_ia" not in form.fields
+    assert "justificativa_ia" not in form.fields
+
+
+def test_anexo_form_define_title_do_tipo_documento_quando_instancia_tem_valor(
+    tipo_documento,
+):
+    tipo_documento.nome = "Documento muito grande para validar o title do select"
+    form = AnexoForm(instance=Anexo(tipo_documento=tipo_documento))
+
+    assert form.fields["tipo_documento"].widget.attrs["title"] == tipo_documento.nome
 
 
 def test_anexo_create_serializer_configura_label_e_help_text():
@@ -68,6 +84,27 @@ def test_anexo_form_aceita_pdf(tipo_documento):
     )
 
     assert form.is_valid(), form.errors
+
+
+@pytest.mark.parametrize("status_admin", [Anexo.STATUS_REPROVADO, Anexo.STATUS_VENCIDO])
+def test_anexo_form_copia_justificativa_ia_para_admin(tipo_documento, status_admin):
+    anexo = Anexo(
+        tipo_documento=tipo_documento,
+        status_ia=Anexo.STATUS_REPROVADO,
+        justificativa_ia="Documento divergente segundo a IA.",
+    )
+    form = AnexoForm(
+        data={
+            "tipo_documento": tipo_documento.id,
+            "status": status_admin,
+            "justificativa": "",
+        },
+        files={"arquivo": create_uploaded_file("anexo.pdf")},
+        instance=anexo,
+    )
+
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["justificativa"] == "Documento divergente segundo a IA."
 
 
 @pytest.mark.parametrize("file_name", ["anexo.jpg", "anexo.png", "anexo.txt"])

--- a/sme_uniforme_apps/proponentes/tests/test_loja/test_endpoint.py
+++ b/sme_uniforme_apps/proponentes/tests/test_loja/test_endpoint.py
@@ -8,10 +8,34 @@ from ...models.loja import Loja
 pytestmark = pytest.mark.django_db
 
 
-def test_update_loja_fachada(client, payload_update_fachada_loja, loja_fisica):
+ARQUIVO_PNG_BASE64 = "data:image/png;base64,iVBORw0KGgo="
+ARQUIVO_JPG_BASE64 = "data:image/jpg;base64,/9j/4AAQSkZJRgABAQ=="
+ARQUIVO_JPEG_BASE64 = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ=="
+ARQUIVO_PDF_BASE64 = "data:application/pdf;base64,JVBERi0xLjQKJUVPRgo="
+ARQUIVO_TXT_BASE64 = "data:text/plain;base64,Q09OVEVVRE8gVEVTVEU="
+
+
+@pytest.mark.parametrize(
+    "foto_fachada", [ARQUIVO_PNG_BASE64, ARQUIVO_JPG_BASE64, ARQUIVO_JPEG_BASE64]
+)
+def test_update_loja_fachada(client, loja_fisica, foto_fachada):
     foto_fachada_antes = Loja.objects.get(uuid=str(loja_fisica.uuid)).foto_fachada
-    response = client.patch("/lojas/{}/".format(loja_fisica.uuid), data=json.dumps(payload_update_fachada_loja), content_type='application/json') 
-    result = json.loads(response.content)
+    response = client.patch("/lojas/{}/".format(loja_fisica.uuid), data=json.dumps({"foto_fachada": foto_fachada}), content_type="application/json")
     assert Loja.objects.exists()
     assert response.status_code == status.HTTP_200_OK
-    assert Loja.objects.get(uuid=str(loja_fisica.uuid)).foto_fachada != foto_fachada_antes
+    assert (Loja.objects.get(uuid=str(loja_fisica.uuid)).foto_fachada != foto_fachada_antes)
+
+
+@pytest.mark.parametrize("foto_fachada", [ARQUIVO_PDF_BASE64, ARQUIVO_TXT_BASE64])
+def test_update_loja_fachada_rejeita_extensao_invalida(
+    client, loja_fisica, foto_fachada
+):
+    response = client.patch(
+        "/lojas/{}/".format(loja_fisica.uuid),
+        data=json.dumps({"foto_fachada": foto_fachada}),
+        content_type="application/json",
+    )
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result["foto_fachada"] == ["Envie a foto da fachada em JPG, JPEG ou PNG."]

--- a/sme_uniforme_apps/proponentes/tests/test_loja/test_model.py
+++ b/sme_uniforme_apps/proponentes/tests/test_loja/test_model.py
@@ -1,13 +1,70 @@
 import pytest
 from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
 
+from ...admin import LojasInLine, LojaAdmin
 from ...models import Loja
+from ...models.forms import LojaAdminForm
 
 pytestmark = pytest.mark.django_db
 
 
+def create_uploaded_file(file_name):
+    return SimpleUploadedFile(file_name, b"conteudo_teste")
+
+
+def create_loja_admin_form(file_name):
+    return LojaAdminForm(
+        data={
+            "nome_fantasia": "Loja Teste",
+            "cep": "27600-000",
+            "endereco": "Rua Teste",
+            "bairro": "Centro",
+            "numero": "123",
+            "complemento": "loja 1",
+            "telefone": "(11) 4565-9876",
+            "numero_iptu": "",
+            "site": "",
+        },
+        files={"foto_fachada": create_uploaded_file(file_name)},
+    )
+
+
 def test_loja(proponente, loja_fisica):
     assert isinstance(loja_fisica, Loja)
+
+
+def test_admin_loja_esconde_comprovante_endereco():
+    assert LojasInLine.form == LojaAdminForm
+    assert LojasInLine.exclude == ("comprovante_endereco",)
+    assert LojaAdmin.exclude == ("comprovante_endereco",)
+
+
+def test_loja_admin_form_configura_label_e_help_text():
+    form = LojaAdminForm()
+
+    assert form.fields["foto_fachada"].label == "Foto da fachada da loja"
+    assert (
+        form.fields["foto_fachada"].help_text
+        == "Envie apenas arquivos JPG, JPEG ou PNG."
+    )
+
+
+@pytest.mark.parametrize("file_name", ["fachada.png", "fachada.jpg", "fachada.jpeg"])
+def test_loja_admin_form_aceita_uploads_de_imagem(file_name):
+    form = create_loja_admin_form(file_name)
+
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.parametrize("file_name", ["fachada.pdf", "fachada.txt"])
+def test_loja_admin_form_rejeita_uploads_invalidos(file_name):
+    form = create_loja_admin_form(file_name)
+
+    assert not form.is_valid()
+    assert form.errors["foto_fachada"] == [
+        "Envie a foto da fachada em JPG, JPEG ou PNG."
+    ]
 
 
 def test_validacao_telefone_fora_formato(proponente):

--- a/sme_uniforme_apps/proponentes/tests/test_loja/test_serializers.py
+++ b/sme_uniforme_apps/proponentes/tests/test_loja/test_serializers.py
@@ -1,7 +1,6 @@
 import pytest
 
-from ...api.serializers.loja_serializer import (LojaSerializer,
-                                                LojaUpdateFachadaSerializer)
+from ...api.serializers.loja_serializer import (LojaCreateSerializer, LojaSerializer, LojaUpdateFachadaSerializer)
 
 pytestmark = pytest.mark.django_db
 
@@ -27,6 +26,43 @@ def test_loja_serializer(loja_fisica):
     assert loja_serializer.data['nome_fantasia']
     assert loja_serializer.data['foto_fachada']
 
+
+def test_loja_create_serializer_configura_campos_de_upload():
+    serializer = LojaCreateSerializer()
+    comprovante = serializer.fields["comprovante_endereco"]
+    foto_fachada = serializer.fields["foto_fachada"]
+
+    assert not comprovante.required
+    assert comprovante.allow_null
+    assert comprovante.label == "Comprovante de endereço do ponto de venda"
+    assert comprovante.help_text == "Campo opcional. Se enviado, deve estar em PDF."
+    assert not foto_fachada.required
+    assert foto_fachada.allow_null
+    assert foto_fachada.label == "Foto da fachada da loja"
+    assert foto_fachada.help_text == "Envie apenas arquivos JPG, JPEG ou PNG."
+
+
+def test_loja_update_fachada_serializer_configura_label_e_help_text():
+    serializer = LojaUpdateFachadaSerializer()
+
+    assert serializer.fields["foto_fachada"].label == "Foto da fachada da loja"
+    assert (
+        serializer.fields["foto_fachada"].help_text
+        == "Envie apenas arquivos JPG, JPEG ou PNG."
+    )
+
+
 def test_loja_fachada_update(payload_update_fachada_loja):
     loja_partial_update = LojaUpdateFachadaSerializer(data=payload_update_fachada_loja)
     assert loja_partial_update.is_valid()
+
+
+def test_loja_fachada_update_rejeita_extensao_invalida(arquivo_txt_base64):
+    loja_partial_update = LojaUpdateFachadaSerializer(
+        data={"foto_fachada": arquivo_txt_base64}
+    )
+
+    assert not loja_partial_update.is_valid()
+    assert loja_partial_update.errors["foto_fachada"] == [
+        "Envie a foto da fachada em JPG, JPEG ou PNG."
+    ]

--- a/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py
+++ b/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py
@@ -1,7 +1,42 @@
+import json
+from unittest.mock import patch
+
 import pytest
 from rest_framework import status
 
 pytestmark = pytest.mark.django_db
+
+
+ARQUIVO_JPG_BASE64 = "data:image/jpg;base64,/9j/4AAQSkZJRgABAQ=="
+
+
+def create_payload_atualiza_lojas(
+    uniforme_nome, comprovante_endereco=None, loja_id=None
+):
+    loja = {
+        "nome_fantasia": "Loja Atualizada",
+        "cep": "27600-000",
+        "endereco": "Rua Atualizada",
+        "bairro": "Centro",
+        "numero": "10",
+        "complemento": "",
+        "telefone": "(11) 4565-9876",
+        "numero_iptu": "",
+    }
+    if loja_id:
+        loja["id"] = loja_id
+    if comprovante_endereco is not None:
+        loja["comprovante_endereco"] = comprovante_endereco
+
+    return {
+        "lojas": [loja],
+        "ofertas_de_uniformes": [
+            {
+                "nome": uniforme_nome,
+                "valor": "10.00",
+            }
+        ],
+    }
 
 
 def test_url_authorized(authenticated_client):
@@ -22,3 +57,86 @@ def test_url_concluir_cadastro(authenticated_client, proponente):
 def test_url_verifica_email(authenticated_client):
     response = authenticated_client.get('/proponentes/verifica-email/')
     assert response.status_code == status.HTTP_200_OK
+
+
+@patch(
+    "sme_uniforme_apps.proponentes.api.viewsets.proponentes_viewset.atualiza_coordenadas_lojas"
+)
+def test_url_atualiza_lojas_sem_comprovante_endereco(
+    mock_atualiza_coordenadas_lojas, client, proponente, uniforme_calca
+):
+    payload = create_payload_atualiza_lojas(uniforme_calca.nome)
+
+    response = client.patch(
+        f"/proponentes/{proponente.uuid}/atualiza-lojas/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert proponente.lojas.count() == 1
+    assert not proponente.lojas.first().comprovante_endereco
+    mock_atualiza_coordenadas_lojas.assert_called_once()
+
+
+@patch(
+    "sme_uniforme_apps.proponentes.api.viewsets.proponentes_viewset.atualiza_coordenadas_lojas"
+)
+def test_url_atualiza_lojas_com_comprovante_endereco_pdf(
+    mock_atualiza_coordenadas_lojas,
+    client,
+    proponente,
+    loja_fisica,
+    uniforme_calca,
+    arquivo_anexo_base64,
+):
+    payload = create_payload_atualiza_lojas(
+        uniforme_calca.nome,
+        comprovante_endereco=arquivo_anexo_base64,
+        loja_id=loja_fisica.id,
+    )
+
+    response = client.patch(
+        f"/proponentes/{proponente.uuid}/atualiza-lojas/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+    loja_fisica.refresh_from_db()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert loja_fisica.comprovante_endereco
+    mock_atualiza_coordenadas_lojas.assert_called_once()
+
+
+@patch(
+    "sme_uniforme_apps.proponentes.api.viewsets.proponentes_viewset.atualiza_coordenadas_lojas"
+)
+@pytest.mark.parametrize(
+    "comprovante_endereco",
+    [ARQUIVO_JPG_BASE64, "data:text/plain;base64,Q09OVEVVRE8gVEVTVEU="],
+)
+def test_url_atualiza_lojas_rejeita_comprovante_endereco_nao_pdf(
+    mock_atualiza_coordenadas_lojas,
+    client,
+    proponente,
+    loja_fisica,
+    uniforme_calca,
+    comprovante_endereco,
+):
+    payload = create_payload_atualiza_lojas(
+        uniforme_calca.nome,
+        comprovante_endereco=comprovante_endereco,
+        loja_id=loja_fisica.id,
+    )
+
+    response = client.patch(
+        f"/proponentes/{proponente.uuid}/atualiza-lojas/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result == ["Envie o comprovante de endereço do ponto de venda em PDF."]
+    mock_atualiza_coordenadas_lojas.assert_not_called()

--- a/sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipo_documento_model.py
+++ b/sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipo_documento_model.py
@@ -3,12 +3,14 @@ from django.contrib import admin
 
 from sme_uniforme_apps.proponentes.admin import TipoDocumentoAdmin
 from sme_uniforme_apps.proponentes.models import TipoDocumento
+from sme_uniforme_apps.proponentes.models.forms import TipoDocumentoAdminForm
 
 pytestmark = pytest.mark.django_db
 
 
 def test_instancia(tipo_documento):
     assert isinstance(tipo_documento, TipoDocumento)
+    assert tipo_documento.identificador
     assert tipo_documento.nome
     assert tipo_documento.obrigatorio
     assert tipo_documento.visivel
@@ -27,6 +29,99 @@ def test_admin():
     model_admin = TipoDocumentoAdmin(TipoDocumento, admin.site)
     # pylint: disable=W0212
     assert admin.site._registry[TipoDocumento]
-    assert model_admin.list_display == ('nome', 'obrigatorio', 'visivel', 'tem_data_validade')
+    assert model_admin.list_display == ('identificador', 'nome', 'obrigatorio', 'visivel', 'tem_data_validade', 'obrigatorio_sme')
     assert model_admin.ordering == ('nome',)
-    assert model_admin.search_fields == ('nome',)
+    assert model_admin.search_fields == ('identificador', 'nome')
+
+
+def test_admin_form_exige_identificador_para_novo_tipo_documento():
+    form = TipoDocumentoAdminForm(
+        data={
+            "nome": "Documento novo",
+            "obrigatorio": True,
+            "visivel": True,
+            "tem_data_validade": False,
+            "obrigatorio_sme": False,
+        }
+    )
+
+    assert not form.is_valid()
+    assert form.errors["identificador"] == ["Informe o identificador alfanumérico."]
+
+
+def test_admin_form_rejeita_edicao_legada_sem_identificador(tipo_documento):
+    tipo_documento.identificador = None
+    tipo_documento.save(update_fields=["identificador"])
+
+    form = TipoDocumentoAdminForm(
+        instance=tipo_documento,
+        data={
+            "identificador": "",
+            "nome": tipo_documento.nome,
+            "obrigatorio": tipo_documento.obrigatorio,
+            "visivel": tipo_documento.visivel,
+            "tem_data_validade": tipo_documento.tem_data_validade,
+            "obrigatorio_sme": tipo_documento.obrigatorio_sme,
+        },
+    )
+
+    assert not form.is_valid()
+    assert form.errors["identificador"] == ["Informe o identificador alfanumérico."]
+
+
+def test_admin_form_rejeita_edicao_de_tipo_parametrizado_sem_identificador(
+    tipo_documento,
+):
+    form = TipoDocumentoAdminForm(
+        instance=tipo_documento,
+        data={
+            "identificador": "",
+            "nome": tipo_documento.nome,
+            "obrigatorio": tipo_documento.obrigatorio,
+            "visivel": tipo_documento.visivel,
+            "tem_data_validade": tipo_documento.tem_data_validade,
+            "obrigatorio_sme": tipo_documento.obrigatorio_sme,
+        },
+    )
+
+    assert not form.is_valid()
+    assert form.errors["identificador"] == ["Informe o identificador alfanumérico."]
+
+
+def test_admin_form_rejeita_identificador_duplicado(tipo_documento):
+    form = TipoDocumentoAdminForm(
+        data={
+            "identificador": tipo_documento.identificador,
+            "nome": "Outro documento",
+            "obrigatorio": True,
+            "visivel": True,
+            "tem_data_validade": False,
+            "obrigatorio_sme": False,
+        }
+    )
+
+    assert not form.is_valid()
+    assert form.errors["identificador"] == [
+        "Já existe um tipo de documento com este identificador."
+    ]
+
+
+def test_admin_form_rejeita_edicao_para_identificador_duplicado_de_outro_tipo(
+    tipo_documento, tipo_documento_nao_obrigatorio
+):
+    form = TipoDocumentoAdminForm(
+        instance=tipo_documento_nao_obrigatorio,
+        data={
+            "identificador": tipo_documento.identificador,
+            "nome": tipo_documento_nao_obrigatorio.nome,
+            "obrigatorio": tipo_documento_nao_obrigatorio.obrigatorio,
+            "visivel": tipo_documento_nao_obrigatorio.visivel,
+            "tem_data_validade": tipo_documento_nao_obrigatorio.tem_data_validade,
+            "obrigatorio_sme": tipo_documento_nao_obrigatorio.obrigatorio_sme,
+        },
+    )
+
+    assert not form.is_valid()
+    assert form.errors["identificador"] == [
+        "Já existe um tipo de documento com este identificador."
+    ]

--- a/sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipo_documento_serializer.py
+++ b/sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipo_documento_serializer.py
@@ -9,6 +9,7 @@ def test_tipo_documento_serializer(tipo_documento):
     tipo_documento_serializer = TipoDocumentoSerializer(tipo_documento)
 
     assert tipo_documento_serializer.data is not None
+    assert tipo_documento_serializer.data['identificador'] == tipo_documento.identificador
     assert tipo_documento_serializer.data['nome']
     assert tipo_documento_serializer.data['obrigatorio']
     assert tipo_documento_serializer.data['id']

--- a/sme_uniforme_apps/proponentes/upload_validation.py
+++ b/sme_uniforme_apps/proponentes/upload_validation.py
@@ -1,0 +1,35 @@
+import os
+
+PDF_EXTENSIONS = ("pdf",)
+IMAGE_EXTENSIONS = ("jpg", "jpeg", "png")
+
+
+def get_upload_extension(value):
+    if not value:
+        return ""
+
+    if hasattr(value, "name"):
+        return _extension_from_name(value.name)
+
+    if isinstance(value, str):
+        if ";base64," in value:
+            header = value.split(";base64,", 1)[0]
+            return header.split("/")[-1].lower()
+
+        return _extension_from_name(value)
+
+    return ""
+
+
+def validate_upload_extension(value, allowed_extensions, error_message):
+    extension = get_upload_extension(value)
+
+    if extension not in allowed_extensions:
+        raise ValueError(error_message)
+
+    return extension
+
+
+def _extension_from_name(file_name):
+    _, extension = os.path.splitext(file_name or "")
+    return extension.lower().lstrip(".")


### PR DESCRIPTION
## 🌿 Contexto

Preparar o backend e o Django Admin para armazenar, exibir e validar o retorno de análise de IA dos anexos de proponentes.

## 🎯 Objetivo

- Permitir que o gestor visualize no Django Admin os dados retornados pela análise de IA dos anexos.
- Separar claramente o resultado da IA da decisão administrativa do gestor.
- Registrar auditoria da validação feita no admin.
- Deixar a estrutura pronta para receber status vindos de uma ferramenta externa, sem depender de `choices` fixos para `Status IA`.

## ✨ O Que Foi Implementado

- O modelo `Anexo` passou a armazenar os campos `status_ia`, `justificativa_ia`, `ultima_alteracao_admin_por` e `ultima_alteracao_admin_em`.
- Os campos já existentes do fluxo administrativo foram semantizados como decisão do gestor: `status` representa `Status Admin` e `justificativa` representa `Justificativa Admin`.
- O campo `status_ia` foi aberto para receber qualquer valor textual vindo de integração externa, sem `choices` fixos.
- O Django Admin passou a exibir `Status IA`, `Justificativa IA`, `Status Admin`, `Justificativa Admin` e a auditoria da última alteração no inline de anexos do proponente.
- A justificativa da IA é copiada automaticamente para a justificativa administrativa quando o gestor marca o anexo como `Reprovado` ou `Vencido` e o campo administrativo ainda está vazio.
- A exibição da `Justificativa IA` foi tratada para ficar vazia quando não houver conteúdo, sem sugerir texto padrão ao usuário.
- O `Status IA` no admin continua exibindo rótulos amigáveis para os status conhecidos do sistema (`Aprovado`, `Reprovado`, `Pendente`, `Vencido`), mas também mostra corretamente qualquer status novo/desconhecido recebido da ferramenta externa.
- O inline do admin recebeu ajustes visuais pontuais via CSS próprio para melhorar largura, alinhamento, leitura da justificativa e comportamento do `tipo_documento` com nomes longos.
- O CSS da visualização foi isolado ao grupo de anexos do inline (`#anexos-group`) para evitar impacto em outras páginas do Django Admin.

## 🧩 Principais Decisões Técnicas

- `status_ia` não depende mais de `choices`; isso evita novo deploy/migration sempre que a ferramenta externa introduzir um status diferente.
- A renderização do `Status IA` no admin usa fallback: se o valor existir em `Anexo.STATUS_NOMES`, o admin mostra o nome amigável; caso contrário, mostra o valor bruto recebido.
- O `AnexoCreateSerializer` continua excluindo os campos de IA e auditoria do fluxo público atual, preservando o contrato atual da API enquanto a integração externa ainda não existe.
- A auditoria do admin usa os campos explícitos `ultima_alteracao_admin_por` e `ultima_alteracao_admin_em`, com fallback para o histórico do `auditlog` quando necessário.

## 🧪 Testes

### ✅ Execução realizada

- Comando executado:
  `docker compose -f docker-compose-dev.yml exec web pytest sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py sme_uniforme_apps/proponentes/tests/test_anexo/test_admin.py -q`
- Resultado validado no estado atual:
  `24 passed`

### 🆕 Testes criados

Arquivo: `sme_uniforme_apps/proponentes/tests/test_anexo/test_admin.py`

- Valida que a tela de edição do proponente exibe `Status IA`, `Justificativa IA`, `Status Admin` e `Justificativa Admin`, sem inputs editáveis para os campos da IA.
- Garante que o salvamento no admin copia a justificativa da IA para o campo administrativo e registra usuário/data da alteração.
- Garante que a informação de auditoria aparece na tela do admin.
- Garante que o texto de auditoria é montado com nome do usuário e data formatada.
- Valida que a justificativa da IA é renderizada em bloco readonly com o atributo `data-justificativa-ia`.
- Garante que a coluna `Justificativa IA` permanece vazia quando não existe conteúdo.
- Valida a renderização compacta do `Status IA` para valores conhecidos.
- Garante que um `Status IA` externo e desconhecido continua sendo exibido corretamente, sem dependência de `choices` fixos.

Arquivo: `sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py`

- Garante que o campo `tipo_documento` recebe `title` com o nome completo do documento quando a instância já possui valor.
- Garante a cópia automática da justificativa da IA para a justificativa administrativa quando o status é marcado como `Reprovado` ou `Vencido`.

### ✏️ Teste alterado

Arquivo: `sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py`

- Valida os labels do `AnexoForm`, o valor inicial do `Status Admin`, os estilos de `tipo_documento` e `justificativa` e a não exposição de `status_ia` e `justificativa_ia` como campos editáveis.

### 🖥️ Validação manual realizada

- Conferência visual do inline de anexos no navegador.
- Verificação de alinhamento entre upload do arquivo, data de validade, `Status IA` e `Status Admin`.
- Verificação de largura ampliada da `Justificativa Admin`.
- Verificação de `tipo_documento` com largura controlada e `title` contendo o nome completo.
- Verificação de `Justificativa IA` vazia sem texto placeholder.
- Verificação de que o CSS dos anexos não é carregado nas listagens `/admin/proponentes/proponente/` e `/admin/proponentes/ofertadeuniforme/`.

## 🔄 Migrações

- Migrations incluídas:
  `0033_anexo_campos_ia_e_auditoria`
  `0034_altera_status_ia_aberto`

## ⚠️ Pontos de Atenção

- A integração com a ferramenta externa de IA ainda não faz parte desta PR; a estrutura foi preparada para recebê-la.
- O fluxo público de criação de anexos continua sem aceitar diretamente campos de IA e auditoria.
- O `Status IA` agora aceita qualquer string externa, por isso, o tratamento visual no admin foi feito para valores conhecidos e desconhecidos.

## ✅ Resumo Final

- A PR prepara o backend para armazenar e exibir o resultado da análise de IA em anexos.
- O gestor passa a validar o resultado diretamente no Django Admin com rastreabilidade.
- O admin foi ajustado para usabilidade real, sem expor edição dos campos vindos da IA.
- O `Status IA` foi desacoplado de `choices` fixos e passou a aceitar valores externos livres.
