### PR TITLE
Feature(148709): Parametrização de Tipos Documentos e Upload Documentos

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,17 @@ pytest.ini
 README.md
 README.rst
 setup.cfg
+.git
+.venv
+.run
+.idea
+.vscode
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+build/
+dist/
+docs/_build/

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,9 @@ dmypy.json
 
 # Media folder
 media/
+
+# run
+.run/
+
+#github
+.github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . /code/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gcc g++ libpq-dev libcairo2 libpango-1.0-0 libpangocairo-1.0-0  && \
     pip install psycopg2-binary && \
-    pip --no-cache-dir install --upgrade pip && \
+    pip --no-cache-dir install --upgrade "pip<24.1" && \
     pip --no-cache-dir install --requirement requirements/production.txt && \
     apt-get remove -y gcc g++ && \
     apt-get autoremove -y && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,28 @@
+FROM python:3.8-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        g++ \
+        libpq-dev \
+        libcairo2 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements /tmp/requirements
+
+RUN pip install --upgrade "pip<24.1" && \
+    pip install --requirement /tmp/requirements/local.txt && \
+    apt-get purge -y gcc g++ && \
+    apt-get autoremove -y
+
+COPY . /app
+
+EXPOSE 8000

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,106 @@
+x-app-base: &app-base
+  image: sme-portaluniforme-backend-dev:local
+  build:
+    context: .
+    dockerfile: Dockerfile.dev
+  env_file:
+    - .env
+  environment:
+    POSTGRES_HOST: db
+    POSTGRES_PORT: 5432
+    REDIS_LOCATION: redis://redis:6379/1
+    SERVER_NAME: http://localhost:${BACKEND_PORT:-8000}
+  volumes:
+    - .:/app
+  depends_on:
+    db:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+
+services:
+  web:
+    <<: *app-base
+    command: >
+      sh -c "
+      python manage.py check &&
+      python manage.py migrate &&
+      exec python manage.py runserver 0.0.0.0:8000
+      "
+    ports:
+      - "${BACKEND_PORT:-8000}:8000"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/docs/', timeout=5)"
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  celery-worker:
+    <<: *app-base
+    command: celery -A config worker --loglevel=info
+    depends_on:
+      web:
+        condition: service_healthy
+
+  celery-beat:
+    <<: *app-base
+    command: celery -A config beat --loglevel=info --scheduler django_celery_beat.schedulers:DatabaseScheduler
+    depends_on:
+      web:
+        condition: service_healthy
+
+  db:
+    image: postgres:11.2-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-admin}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-12345qw}
+      POSTGRES_DB: ${POSTGRES_DB:-uniformes}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-12345qw}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U ${POSTGRES_USER:-admin} -d ${POSTGRES_DB:-uniformes}
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:5.0.0-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    ports:
+      - "${REDIS_HOST_PORT:-6379}:6379"
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - ping
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  pgadmin4:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-matheus.jesus@spassu.com.br}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-adminadmin}
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    ports:
+      - "${PGADMIN_PORT:-9090}:80"
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  redis_data:
+  pgadmin_data:

--- a/sme_uniforme_apps/proponentes/admin.py
+++ b/sme_uniforme_apps/proponentes/admin.py
@@ -1,4 +1,3 @@
-import csv
 from io import BytesIO
 
 from django.contrib import admin
@@ -12,7 +11,7 @@ from openpyxl.writer.excel import save_virtual_workbook
 
 from .models import (Anexo, ListaNegra, Loja, OfertaDeUniforme, Proponente,
                      TipoDocumento)
-from .models.forms import AnexoForm
+from .models.forms import AnexoForm, LojaAdminForm, TipoDocumentoAdminForm
 from .services import (atualiza_coordenadas, cnpj_esta_bloqueado,
                        muda_status_de_proponentes, cria_usuario_proponentes_existentes, envia_email_pendencias)
 
@@ -23,7 +22,9 @@ class UniformesFornecidosInLine(admin.TabularInline):
 
 
 class LojasInLine(admin.StackedInline):
+    form = LojaAdminForm
     model = Loja
+    exclude = ('comprovante_endereco',)
     extra = 1  # Quantidade de linhas que serão exibidas.
 
 
@@ -245,6 +246,9 @@ class ListaNegraAdmin(admin.ModelAdmin):
 
 @admin.register(Loja)
 class LojaAdmin(admin.ModelAdmin):
+    form = LojaAdminForm
+    exclude = ('comprovante_endereco',)
+
     @staticmethod
     def protocolo(loja):
         return loja.proponente.protocolo
@@ -265,6 +269,8 @@ class LojaAdmin(admin.ModelAdmin):
 
 @admin.register(TipoDocumento)
 class TipoDocumentoAdmin(admin.ModelAdmin):
+    form = TipoDocumentoAdminForm
+
     def inverte_visivel(self, request, queryset):
         for tipo_documento in queryset.all():
             tipo_documento.visivel = not tipo_documento.visivel
@@ -283,8 +289,8 @@ class TipoDocumentoAdmin(admin.ModelAdmin):
 
     inverte_obrigatorio.short_description = "Inverter o parâmetro 'obrigatório' "
 
-    list_display = ('nome', 'obrigatorio', 'visivel', 'tem_data_validade', 'obrigatorio_sme')
+    list_display = ('identificador', 'nome', 'obrigatorio', 'visivel', 'tem_data_validade', 'obrigatorio_sme')
     ordering = ('nome',)
-    search_fields = ('nome',)
+    search_fields = ('identificador', 'nome')
     list_filter = ('obrigatorio', 'visivel')
     actions = ['inverte_visivel', 'inverte_obrigatorio']

--- a/sme_uniforme_apps/proponentes/api/serializers/anexo_serializer.py
+++ b/sme_uniforme_apps/proponentes/api/serializers/anexo_serializer.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 
 from .tipo_documento_serializer import TipoDocumentoSerializer
 from ...models import Anexo, Proponente
+from ...upload_validation import PDF_EXTENSIONS, validate_upload_extension
 
 log = logging.getLogger(__name__)
 
@@ -20,6 +21,14 @@ class AnexoSerializer(ModelSerializer):
 
 class AnexoCreateSerializer(serializers.ModelSerializer):
     proponente = serializers.UUIDField()
+
+    def validate_arquivo(self, value):
+        try:
+            validate_upload_extension(value, PDF_EXTENSIONS, 'Envie o documento do proponente em PDF.')
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc))
+
+        return value
 
     def create(self, validated_data):
         log.info("Criando anexo!")
@@ -44,3 +53,9 @@ class AnexoCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Anexo
         exclude = ('id',)
+        extra_kwargs = {
+            'arquivo': {
+                'label': 'Documento do proponente',
+                'help_text': 'Envie apenas arquivos PDF.',
+            }
+        }

--- a/sme_uniforme_apps/proponentes/api/serializers/loja_serializer.py
+++ b/sme_uniforme_apps/proponentes/api/serializers/loja_serializer.py
@@ -1,9 +1,12 @@
 import environ
 
 from rest_framework import serializers
-from config.settings.base import MEDIA_URL
 from ...models import Loja
-
+from ...upload_validation import (
+    IMAGE_EXTENSIONS,
+    PDF_EXTENSIONS,
+    validate_upload_extension,
+)
 
 env = environ.Env()
 SERVER_NAME = f'{env("SERVER_NAME")}'
@@ -28,15 +31,72 @@ class LojaSerializer(serializers.ModelSerializer):
 
 class LojaCreateSerializer(serializers.ModelSerializer):
 
+    def validate_foto_fachada(self, value):
+        if not value:
+            return value
+
+        try:
+            validate_upload_extension(value, IMAGE_EXTENSIONS, 'Envie a foto da fachada em JPG, JPEG ou PNG.')
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc))
+
+        return value
+
+    def validate_comprovante_endereco(self, value):
+        if not value:
+            return value
+
+        try:
+            validate_upload_extension(
+                value,
+                PDF_EXTENSIONS,
+                'Envie o comprovante de endereço do ponto de venda em PDF.',
+            )
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc))
+
+        return value
+
     class Meta:
         model = Loja
         exclude = ('id', 'proponente')
+        extra_kwargs = {
+            'comprovante_endereco': {
+                'label': 'Comprovante de endereço do ponto de venda',
+                'help_text': 'Campo opcional. Se enviado, deve estar em PDF.',
+                'required': False,
+                'allow_null': True,
+            },
+            'foto_fachada': {
+                'label': 'Foto da fachada da loja',
+                'help_text': 'Envie apenas arquivos JPG, JPEG ou PNG.',
+                'required': False,
+                'allow_null': True,
+            },
+        }
 
 
 class LojaUpdateFachadaSerializer(serializers.ModelSerializer):
     uuid = serializers.UUIDField(read_only=True)
     nome_fantasia = serializers.CharField(read_only=True)
 
+    def validate_foto_fachada(self, value):
+        if not value:
+            return value
+
+        try:
+            validate_upload_extension(value, IMAGE_EXTENSIONS, 'Envie a foto da fachada em JPG, JPEG ou PNG.')
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc))
+
+        return value
+
     class Meta:
         model = Loja
         fields = ('uuid', 'nome_fantasia', 'foto_fachada',)
+        extra_kwargs = {
+            'foto_fachada': {
+                'label': 'Foto da fachada da loja',
+                'help_text': 'Envie apenas arquivos JPG, JPEG ou PNG.',
+            }
+        }

--- a/sme_uniforme_apps/proponentes/api/serializers/tipo_documento_serializer.py
+++ b/sme_uniforme_apps/proponentes/api/serializers/tipo_documento_serializer.py
@@ -6,4 +6,4 @@ from ...models import TipoDocumento
 class TipoDocumentoSerializer(serializers.ModelSerializer):
     class Meta:
         model = TipoDocumento
-        fields = ('id', 'nome', 'obrigatorio', 'tem_data_validade', 'obrigatorio_sme')
+        fields = ('id', 'identificador', 'nome', 'obrigatorio', 'tem_data_validade', 'obrigatorio_sme')

--- a/sme_uniforme_apps/proponentes/api/viewsets/proponentes_viewset.py
+++ b/sme_uniforme_apps/proponentes/api/viewsets/proponentes_viewset.py
@@ -13,6 +13,7 @@ from sme_uniforme_apps.core.models import Uniforme
 from sme_uniforme_apps.proponentes.api.serializers.loja_serializer import LojaCreateSerializer
 from sme_uniforme_apps.proponentes.models import OfertaDeUniforme
 from sme_uniforme_apps.proponentes.services import atualiza_coordenadas_lojas
+from sme_uniforme_apps.proponentes.upload_validation import PDF_EXTENSIONS, validate_upload_extension
 from ..serializers.proponente_serializer import ProponenteSerializer, ProponenteCreateSerializer
 
 from ...models import Proponente, ListaNegra, Loja
@@ -87,8 +88,18 @@ class ProponentesViewSet(mixins.CreateModelMixin,
                 loja_obj.nome_fantasia = loja.get('nome_fantasia')
                 loja_obj.telefone = loja.get('telefone')
                 loja_obj.site = loja.get('site')
-                if loja.get('comprovante_endereco') is not None:
-                    file = base64ToFile(loja.get('comprovante_endereco'))
+                comprovante_endereco = loja.get('comprovante_endereco')
+                if comprovante_endereco:
+                    try:
+                        validate_upload_extension(
+                            comprovante_endereco,
+                            PDF_EXTENSIONS,
+                            'Envie o comprovante de endereço do ponto de venda em PDF.',
+                        )
+                    except ValueError as exc:
+                        raise ValidationError(str(exc))
+
+                    file = base64ToFile(comprovante_endereco)
                     loja_obj.comprovante_endereco.save('comprovante_endereco_loja.' + file['ext'], file['data'])
                 loja_obj.save()
             else:
@@ -97,10 +108,20 @@ class ProponentesViewSet(mixins.CreateModelMixin,
                                     'uf', 'firstName']
                 for attr in atributos_extras:
                     loja.pop(attr, '')
-                comprovante = loja.pop('comprovante_endereco', '')    
+                comprovante = loja.pop('comprovante_endereco', None)
                 loja_object = LojaCreateSerializer().create(loja)
-                file = base64ToFile(comprovante)
-                loja_object.comprovante_endereco.save('comprovante_endereco_loja.' + file['ext'], file['data'])
+                if comprovante:
+                    try:
+                        validate_upload_extension(
+                            comprovante,
+                            PDF_EXTENSIONS,
+                            'Envie o comprovante de endereço do ponto de venda em PDF.',
+                        )
+                    except ValueError as exc:
+                        raise ValidationError(str(exc))
+
+                    file = base64ToFile(comprovante)
+                    loja_object.comprovante_endereco.save('comprovante_endereco_loja.' + file['ext'], file['data'])
                 proponente.lojas.add(loja_object)
                 lojas_ids.append(loja_object.id)
         atualiza_coordenadas_lojas(proponente.lojas)

--- a/sme_uniforme_apps/proponentes/api/viewsets/tipos_documento_viewset.py
+++ b/sme_uniforme_apps/proponentes/api/viewsets/tipos_documento_viewset.py
@@ -13,8 +13,8 @@ class TiposDocumentoViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = TipoDocumentoSerializer
     permission_classes = [AllowAny]
     filter_backends = (filters.DjangoFilterBackend, SearchFilter, OrderingFilter)
-    ordering_fields = ('nome',)
-    search_fields = ('uuid', 'id', 'nome')
+    ordering_fields = ('nome', 'identificador')
+    search_fields = ('uuid', 'id', 'nome', 'identificador')
     filter_fields = ('obrigatorio',)
 
     def get_queryset(self):

--- a/sme_uniforme_apps/proponentes/migrations/0032_tipodocumento_identificador.py
+++ b/sme_uniforme_apps/proponentes/migrations/0032_tipodocumento_identificador.py
@@ -1,0 +1,30 @@
+from django.core.validators import RegexValidator
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("proponentes", "0031_auto_20220215_1457"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="tipodocumento",
+            name="identificador",
+            field=models.CharField(
+                blank=True,
+                help_text="Use apenas letras, números, hífen e underscore.",
+                max_length=100,
+                null=True,
+                unique=True,
+                validators=[
+                    RegexValidator(
+                        message="Use apenas letras, números, hífen e underscore.",
+                        regex="^[0-9A-Za-z_-]+$",
+                    )
+                ],
+                verbose_name="Identificador",
+            ),
+        ),
+    ]

--- a/sme_uniforme_apps/proponentes/models/forms.py
+++ b/sme_uniforme_apps/proponentes/models/forms.py
@@ -1,6 +1,11 @@
 from django import forms
 
-from sme_uniforme_apps.proponentes.models import Anexo
+from sme_uniforme_apps.proponentes.models import Anexo, Loja, TipoDocumento
+from sme_uniforme_apps.proponentes.upload_validation import (
+    IMAGE_EXTENSIONS,
+    PDF_EXTENSIONS,
+    validate_upload_extension,
+)
 
 
 class AnexoForm(forms.ModelForm):
@@ -8,8 +13,92 @@ class AnexoForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(AnexoForm, self).__init__(*args, **kwargs)
 
-        self.fields['tipo_documento'].required = True
+        self.fields["tipo_documento"].required = True
+        self.fields["arquivo"].label = "Documento do proponente"
+        self.fields["arquivo"].help_text = "Envie apenas arquivos PDF."
+
+    def clean_arquivo(self):
+        arquivo = self.cleaned_data.get("arquivo")
+
+        if not arquivo or "arquivo" not in self.changed_data:
+            return arquivo
+
+        try:
+            validate_upload_extension(
+                arquivo,
+                PDF_EXTENSIONS,
+                "Envie o documento do proponente em PDF.",
+            )
+        except ValueError as exc:
+            raise forms.ValidationError(str(exc))
+
+        return arquivo
 
     class Meta:
         model = Anexo
         fields = '__all__'
+
+
+class LojaAdminForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super(LojaAdminForm, self).__init__(*args, **kwargs)
+
+        self.fields["foto_fachada"].label = "Foto da fachada da loja"
+        self.fields["foto_fachada"].help_text = (
+            "Envie apenas arquivos JPG, JPEG ou PNG."
+        )
+
+    def clean_foto_fachada(self):
+        foto_fachada = self.cleaned_data.get("foto_fachada")
+
+        if not foto_fachada or "foto_fachada" not in self.changed_data:
+            return foto_fachada
+
+        try:
+            validate_upload_extension(
+                foto_fachada,
+                IMAGE_EXTENSIONS,
+                "Envie a foto da fachada em JPG, JPEG ou PNG.",
+            )
+        except ValueError as exc:
+            raise forms.ValidationError(str(exc))
+
+        return foto_fachada
+
+    class Meta:
+        model = Loja
+        fields = "__all__"
+
+
+class TipoDocumentoAdminForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super(TipoDocumentoAdminForm, self).__init__(*args, **kwargs)
+
+        self.fields["identificador"].required = True
+        self.fields["identificador"].error_messages[
+            "required"
+        ] = "Informe o identificador alfanumérico."
+
+    def clean_identificador(self):
+        identificador = (self.cleaned_data.get("identificador") or "").strip() or None
+
+        if not identificador:
+            raise forms.ValidationError("Informe o identificador alfanumérico.")
+
+        if (
+            identificador
+            and TipoDocumento.objects.exclude(pk=self.instance.pk)
+            .filter(identificador=identificador)
+            .exists()
+        ):
+            raise forms.ValidationError(
+                "Já existe um tipo de documento com este identificador."
+            )
+
+        return identificador
+
+    class Meta:
+        model = TipoDocumento
+        fields = "__all__"

--- a/sme_uniforme_apps/proponentes/models/tipo_documento.py
+++ b/sme_uniforme_apps/proponentes/models/tipo_documento.py
@@ -1,9 +1,24 @@
+from django.core.validators import RegexValidator
 from django.db import models
 
 from sme_uniforme_apps.core.models_abstracts import ModeloBase
 
 
 class TipoDocumento(ModeloBase):
+    identificador = models.CharField(
+        "Identificador",
+        max_length=100,
+        unique=True,
+        blank=True,
+        null=True,
+        help_text="Use apenas letras, números, hífen e underscore.",
+        validators=[
+            RegexValidator(
+                regex=r"^[0-9A-Za-z_-]+$",
+                message="Use apenas letras, números, hífen e underscore.",
+            )
+        ],
+    )
     nome = models.TextField('Tipo de documento', unique=True)
     obrigatorio = models.BooleanField(default=True)
     visivel = models.BooleanField(default=True)

--- a/sme_uniforme_apps/proponentes/tests/conftest.py
+++ b/sme_uniforme_apps/proponentes/tests/conftest.py
@@ -48,9 +48,9 @@ def loja_fisica(proponente, arquivo):
     )
 
 @pytest.fixture
-def payload_update_fachada_loja(arquivo_anexo_base64):
+def payload_update_fachada_loja(arquivo_fachada_base64):
     return {
-        "foto_fachada": arquivo_anexo_base64,
+        "foto_fachada": arquivo_fachada_base64,
     }
 
 
@@ -104,6 +104,7 @@ def proponente_bloqueado(cnpj_bloqueado, lista_negra):
 def tipo_documento():
     return baker.make(
         'TipoDocumento',
+        identificador='CERTIDAO_NEGATIVA',
         nome='Certidão Negativa',
         obrigatorio=True,
         visivel=True
@@ -114,6 +115,7 @@ def tipo_documento():
 def tipo_documento_nao_obrigatorio():
     return baker.make(
         'TipoDocumento',
+        identificador='CARTA_RECOMENDACAO',
         nome='Carta de Recomendação',
         obrigatorio=False,
     )
@@ -121,7 +123,18 @@ def tipo_documento_nao_obrigatorio():
 
 @pytest.fixture
 def arquivo_anexo_base64():
-    return "data:text/plain/txt;base64,RW5kZXJl528gSVB2NDoJMTAuNDkuMjMuOTANClNlcnZpZG9yZXMgRE5TIElQdjQ6CTEwLjQ5LjE2LjQwCjEwLjQ5LjE2LjQzDQpTdWZpeG8gRE5TIFByaW3hcmlvOgllZHVjYWNhby5pbnRyYW5ldA0KRmFicmljYW50ZToJSW50ZWwNCkRlc2NyaefjbzoJSW50ZWwoUikgRXRoZXJuZXQgQ29ubmVjdGlvbiBJMjE4LUxNDQpWZXJz428gZG8gZHJpdmVyOgkxMi4xMy4xNy40DQpFbmRlcmXnbyBm7XNpY28gKE1BQyk6CTc0LUU2LUUyLUQwLUVDLTNF"
+    return "data:application/pdf;base64,JVBERi0xLjQKJUVPRgo="
+
+
+@pytest.fixture
+def arquivo_fachada_base64():
+    return "data:image/png;base64,iVBORw0KGgo="
+
+
+@pytest.fixture
+def arquivo_txt_base64():
+    return "data:text/plain;base64,Q09OVEVVRE8gVEVTVEU="
+
 
 @pytest.fixture
 def payload_anexo(arquivo_anexo_base64, tipo_documento, proponente):
@@ -219,7 +232,7 @@ def payload_ofertas_de_uniformes_faltando_a_camisa(uniforme_calca, uniforme_teni
 
 
 @pytest.fixture
-def payload_lojas(arquivo_anexo_base64):
+def payload_lojas(arquivo_fachada_base64):
     return [
         {
             "nome_fantasia": "Loja A",
@@ -232,7 +245,7 @@ def payload_lojas(arquivo_anexo_base64):
             "longitude": 0,
             "numero_iptu": "",
             "telefone": "(55) 4344-8765",
-            "foto_fachada": arquivo_anexo_base64
+            "foto_fachada": arquivo_fachada_base64
         },
         {
             "nome_fantasia": "Loja B",
@@ -244,7 +257,7 @@ def payload_lojas(arquivo_anexo_base64):
             "longitude": 0,
             "numero_iptu": "",
             "telefone": "(24) 9988-29105",
-            "foto_fachada": arquivo_anexo_base64
+            "foto_fachada": arquivo_fachada_base64
         }
     ]
 

--- a/sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py
+++ b/sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py
@@ -1,11 +1,23 @@
 import json
 
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework import status
 
+from ...api.serializers.anexo_serializer import AnexoCreateSerializer
+from ...models.forms import AnexoForm
 from ...models.anexo import Anexo
 
 pytestmark = pytest.mark.django_db
+
+
+ARQUIVO_JPG_BASE64 = "data:image/jpg;base64,/9j/4AAQSkZJRgABAQ=="
+ARQUIVO_PNG_BASE64 = "data:image/png;base64,iVBORw0KGgo="
+ARQUIVO_TXT_BASE64 = "data:text/plain;base64,Q09OVEVVRE8gVEVTVEU="
+
+
+def create_uploaded_file(file_name):
+    return SimpleUploadedFile(file_name, b"conteudo_teste")
 
 
 @pytest.fixture
@@ -30,3 +42,58 @@ def test_anexo_api_delete_model(delete):
 
 def test_anexo_api_create_model_not_exists(client, delete):
     assert not Anexo.objects.exists()
+
+
+def test_anexo_form_configura_label_e_help_text():
+    form = AnexoForm()
+
+    assert form.fields["arquivo"].label == "Documento do proponente"
+    assert form.fields["arquivo"].help_text == "Envie apenas arquivos PDF."
+
+
+def test_anexo_create_serializer_configura_label_e_help_text():
+    serializer = AnexoCreateSerializer()
+
+    assert serializer.fields["arquivo"].label == "Documento do proponente"
+    assert serializer.fields["arquivo"].help_text == "Envie apenas arquivos PDF."
+
+
+def test_anexo_form_aceita_pdf(tipo_documento):
+    form = AnexoForm(
+        data={
+            "tipo_documento": tipo_documento.id,
+            "status": Anexo.STATUS_PENDENTE,
+        },
+        files={"arquivo": create_uploaded_file("anexo.pdf")},
+    )
+
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.parametrize("file_name", ["anexo.jpg", "anexo.png", "anexo.txt"])
+def test_anexo_form_rejeita_arquivo_nao_pdf(tipo_documento, file_name):
+    form = AnexoForm(
+        data={
+            "tipo_documento": tipo_documento.id,
+            "status": Anexo.STATUS_PENDENTE,
+        },
+        files={"arquivo": create_uploaded_file(file_name)},
+    )
+
+    assert not form.is_valid()
+    assert form.errors["arquivo"] == ["Envie o documento do proponente em PDF."]
+
+
+@pytest.mark.parametrize(
+    "arquivo_invalido", [ARQUIVO_JPG_BASE64, ARQUIVO_PNG_BASE64, ARQUIVO_TXT_BASE64]
+)
+def test_anexo_api_rejeita_arquivo_nao_pdf(client, payload_anexo, arquivo_invalido):
+    payload_anexo["arquivo"] = arquivo_invalido
+
+    response = client.post(
+        "/anexos/", data=json.dumps(payload_anexo), content_type="application/json"
+    )
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result["arquivo"] == ["Envie o documento do proponente em PDF."]

--- a/sme_uniforme_apps/proponentes/tests/test_loja/test_endpoint.py
+++ b/sme_uniforme_apps/proponentes/tests/test_loja/test_endpoint.py
@@ -8,10 +8,34 @@ from ...models.loja import Loja
 pytestmark = pytest.mark.django_db
 
 
-def test_update_loja_fachada(client, payload_update_fachada_loja, loja_fisica):
+ARQUIVO_PNG_BASE64 = "data:image/png;base64,iVBORw0KGgo="
+ARQUIVO_JPG_BASE64 = "data:image/jpg;base64,/9j/4AAQSkZJRgABAQ=="
+ARQUIVO_JPEG_BASE64 = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ=="
+ARQUIVO_PDF_BASE64 = "data:application/pdf;base64,JVBERi0xLjQKJUVPRgo="
+ARQUIVO_TXT_BASE64 = "data:text/plain;base64,Q09OVEVVRE8gVEVTVEU="
+
+
+@pytest.mark.parametrize(
+    "foto_fachada", [ARQUIVO_PNG_BASE64, ARQUIVO_JPG_BASE64, ARQUIVO_JPEG_BASE64]
+)
+def test_update_loja_fachada(client, loja_fisica, foto_fachada):
     foto_fachada_antes = Loja.objects.get(uuid=str(loja_fisica.uuid)).foto_fachada
-    response = client.patch("/lojas/{}/".format(loja_fisica.uuid), data=json.dumps(payload_update_fachada_loja), content_type='application/json') 
-    result = json.loads(response.content)
+    response = client.patch("/lojas/{}/".format(loja_fisica.uuid), data=json.dumps({"foto_fachada": foto_fachada}), content_type="application/json")
     assert Loja.objects.exists()
     assert response.status_code == status.HTTP_200_OK
-    assert Loja.objects.get(uuid=str(loja_fisica.uuid)).foto_fachada != foto_fachada_antes
+    assert (Loja.objects.get(uuid=str(loja_fisica.uuid)).foto_fachada != foto_fachada_antes)
+
+
+@pytest.mark.parametrize("foto_fachada", [ARQUIVO_PDF_BASE64, ARQUIVO_TXT_BASE64])
+def test_update_loja_fachada_rejeita_extensao_invalida(
+    client, loja_fisica, foto_fachada
+):
+    response = client.patch(
+        "/lojas/{}/".format(loja_fisica.uuid),
+        data=json.dumps({"foto_fachada": foto_fachada}),
+        content_type="application/json",
+    )
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result["foto_fachada"] == ["Envie a foto da fachada em JPG, JPEG ou PNG."]

--- a/sme_uniforme_apps/proponentes/tests/test_loja/test_model.py
+++ b/sme_uniforme_apps/proponentes/tests/test_loja/test_model.py
@@ -1,13 +1,70 @@
 import pytest
 from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
 
+from ...admin import LojasInLine, LojaAdmin
 from ...models import Loja
+from ...models.forms import LojaAdminForm
 
 pytestmark = pytest.mark.django_db
 
 
+def create_uploaded_file(file_name):
+    return SimpleUploadedFile(file_name, b"conteudo_teste")
+
+
+def create_loja_admin_form(file_name):
+    return LojaAdminForm(
+        data={
+            "nome_fantasia": "Loja Teste",
+            "cep": "27600-000",
+            "endereco": "Rua Teste",
+            "bairro": "Centro",
+            "numero": "123",
+            "complemento": "loja 1",
+            "telefone": "(11) 4565-9876",
+            "numero_iptu": "",
+            "site": "",
+        },
+        files={"foto_fachada": create_uploaded_file(file_name)},
+    )
+
+
 def test_loja(proponente, loja_fisica):
     assert isinstance(loja_fisica, Loja)
+
+
+def test_admin_loja_esconde_comprovante_endereco():
+    assert LojasInLine.form == LojaAdminForm
+    assert LojasInLine.exclude == ("comprovante_endereco",)
+    assert LojaAdmin.exclude == ("comprovante_endereco",)
+
+
+def test_loja_admin_form_configura_label_e_help_text():
+    form = LojaAdminForm()
+
+    assert form.fields["foto_fachada"].label == "Foto da fachada da loja"
+    assert (
+        form.fields["foto_fachada"].help_text
+        == "Envie apenas arquivos JPG, JPEG ou PNG."
+    )
+
+
+@pytest.mark.parametrize("file_name", ["fachada.png", "fachada.jpg", "fachada.jpeg"])
+def test_loja_admin_form_aceita_uploads_de_imagem(file_name):
+    form = create_loja_admin_form(file_name)
+
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.parametrize("file_name", ["fachada.pdf", "fachada.txt"])
+def test_loja_admin_form_rejeita_uploads_invalidos(file_name):
+    form = create_loja_admin_form(file_name)
+
+    assert not form.is_valid()
+    assert form.errors["foto_fachada"] == [
+        "Envie a foto da fachada em JPG, JPEG ou PNG."
+    ]
 
 
 def test_validacao_telefone_fora_formato(proponente):

--- a/sme_uniforme_apps/proponentes/tests/test_loja/test_serializers.py
+++ b/sme_uniforme_apps/proponentes/tests/test_loja/test_serializers.py
@@ -1,7 +1,6 @@
 import pytest
 
-from ...api.serializers.loja_serializer import (LojaSerializer,
-                                                LojaUpdateFachadaSerializer)
+from ...api.serializers.loja_serializer import (LojaCreateSerializer, LojaSerializer, LojaUpdateFachadaSerializer)
 
 pytestmark = pytest.mark.django_db
 
@@ -27,6 +26,43 @@ def test_loja_serializer(loja_fisica):
     assert loja_serializer.data['nome_fantasia']
     assert loja_serializer.data['foto_fachada']
 
+
+def test_loja_create_serializer_configura_campos_de_upload():
+    serializer = LojaCreateSerializer()
+    comprovante = serializer.fields["comprovante_endereco"]
+    foto_fachada = serializer.fields["foto_fachada"]
+
+    assert not comprovante.required
+    assert comprovante.allow_null
+    assert comprovante.label == "Comprovante de endereço do ponto de venda"
+    assert comprovante.help_text == "Campo opcional. Se enviado, deve estar em PDF."
+    assert not foto_fachada.required
+    assert foto_fachada.allow_null
+    assert foto_fachada.label == "Foto da fachada da loja"
+    assert foto_fachada.help_text == "Envie apenas arquivos JPG, JPEG ou PNG."
+
+
+def test_loja_update_fachada_serializer_configura_label_e_help_text():
+    serializer = LojaUpdateFachadaSerializer()
+
+    assert serializer.fields["foto_fachada"].label == "Foto da fachada da loja"
+    assert (
+        serializer.fields["foto_fachada"].help_text
+        == "Envie apenas arquivos JPG, JPEG ou PNG."
+    )
+
+
 def test_loja_fachada_update(payload_update_fachada_loja):
     loja_partial_update = LojaUpdateFachadaSerializer(data=payload_update_fachada_loja)
     assert loja_partial_update.is_valid()
+
+
+def test_loja_fachada_update_rejeita_extensao_invalida(arquivo_txt_base64):
+    loja_partial_update = LojaUpdateFachadaSerializer(
+        data={"foto_fachada": arquivo_txt_base64}
+    )
+
+    assert not loja_partial_update.is_valid()
+    assert loja_partial_update.errors["foto_fachada"] == [
+        "Envie a foto da fachada em JPG, JPEG ou PNG."
+    ]

--- a/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py
+++ b/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py
@@ -1,7 +1,42 @@
+import json
+from unittest.mock import patch
+
 import pytest
 from rest_framework import status
 
 pytestmark = pytest.mark.django_db
+
+
+ARQUIVO_JPG_BASE64 = "data:image/jpg;base64,/9j/4AAQSkZJRgABAQ=="
+
+
+def create_payload_atualiza_lojas(
+    uniforme_nome, comprovante_endereco=None, loja_id=None
+):
+    loja = {
+        "nome_fantasia": "Loja Atualizada",
+        "cep": "27600-000",
+        "endereco": "Rua Atualizada",
+        "bairro": "Centro",
+        "numero": "10",
+        "complemento": "",
+        "telefone": "(11) 4565-9876",
+        "numero_iptu": "",
+    }
+    if loja_id:
+        loja["id"] = loja_id
+    if comprovante_endereco is not None:
+        loja["comprovante_endereco"] = comprovante_endereco
+
+    return {
+        "lojas": [loja],
+        "ofertas_de_uniformes": [
+            {
+                "nome": uniforme_nome,
+                "valor": "10.00",
+            }
+        ],
+    }
 
 
 def test_url_authorized(authenticated_client):
@@ -22,3 +57,86 @@ def test_url_concluir_cadastro(authenticated_client, proponente):
 def test_url_verifica_email(authenticated_client):
     response = authenticated_client.get('/proponentes/verifica-email/')
     assert response.status_code == status.HTTP_200_OK
+
+
+@patch(
+    "sme_uniforme_apps.proponentes.api.viewsets.proponentes_viewset.atualiza_coordenadas_lojas"
+)
+def test_url_atualiza_lojas_sem_comprovante_endereco(
+    mock_atualiza_coordenadas_lojas, client, proponente, uniforme_calca
+):
+    payload = create_payload_atualiza_lojas(uniforme_calca.nome)
+
+    response = client.patch(
+        f"/proponentes/{proponente.uuid}/atualiza-lojas/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert proponente.lojas.count() == 1
+    assert not proponente.lojas.first().comprovante_endereco
+    mock_atualiza_coordenadas_lojas.assert_called_once()
+
+
+@patch(
+    "sme_uniforme_apps.proponentes.api.viewsets.proponentes_viewset.atualiza_coordenadas_lojas"
+)
+def test_url_atualiza_lojas_com_comprovante_endereco_pdf(
+    mock_atualiza_coordenadas_lojas,
+    client,
+    proponente,
+    loja_fisica,
+    uniforme_calca,
+    arquivo_anexo_base64,
+):
+    payload = create_payload_atualiza_lojas(
+        uniforme_calca.nome,
+        comprovante_endereco=arquivo_anexo_base64,
+        loja_id=loja_fisica.id,
+    )
+
+    response = client.patch(
+        f"/proponentes/{proponente.uuid}/atualiza-lojas/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+    loja_fisica.refresh_from_db()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert loja_fisica.comprovante_endereco
+    mock_atualiza_coordenadas_lojas.assert_called_once()
+
+
+@patch(
+    "sme_uniforme_apps.proponentes.api.viewsets.proponentes_viewset.atualiza_coordenadas_lojas"
+)
+@pytest.mark.parametrize(
+    "comprovante_endereco",
+    [ARQUIVO_JPG_BASE64, "data:text/plain;base64,Q09OVEVVRE8gVEVTVEU="],
+)
+def test_url_atualiza_lojas_rejeita_comprovante_endereco_nao_pdf(
+    mock_atualiza_coordenadas_lojas,
+    client,
+    proponente,
+    loja_fisica,
+    uniforme_calca,
+    comprovante_endereco,
+):
+    payload = create_payload_atualiza_lojas(
+        uniforme_calca.nome,
+        comprovante_endereco=comprovante_endereco,
+        loja_id=loja_fisica.id,
+    )
+
+    response = client.patch(
+        f"/proponentes/{proponente.uuid}/atualiza-lojas/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result == ["Envie o comprovante de endereço do ponto de venda em PDF."]
+    mock_atualiza_coordenadas_lojas.assert_not_called()

--- a/sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipo_documento_model.py
+++ b/sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipo_documento_model.py
@@ -3,12 +3,14 @@ from django.contrib import admin
 
 from sme_uniforme_apps.proponentes.admin import TipoDocumentoAdmin
 from sme_uniforme_apps.proponentes.models import TipoDocumento
+from sme_uniforme_apps.proponentes.models.forms import TipoDocumentoAdminForm
 
 pytestmark = pytest.mark.django_db
 
 
 def test_instancia(tipo_documento):
     assert isinstance(tipo_documento, TipoDocumento)
+    assert tipo_documento.identificador
     assert tipo_documento.nome
     assert tipo_documento.obrigatorio
     assert tipo_documento.visivel
@@ -27,6 +29,99 @@ def test_admin():
     model_admin = TipoDocumentoAdmin(TipoDocumento, admin.site)
     # pylint: disable=W0212
     assert admin.site._registry[TipoDocumento]
-    assert model_admin.list_display == ('nome', 'obrigatorio', 'visivel', 'tem_data_validade')
+    assert model_admin.list_display == ('identificador', 'nome', 'obrigatorio', 'visivel', 'tem_data_validade', 'obrigatorio_sme')
     assert model_admin.ordering == ('nome',)
-    assert model_admin.search_fields == ('nome',)
+    assert model_admin.search_fields == ('identificador', 'nome')
+
+
+def test_admin_form_exige_identificador_para_novo_tipo_documento():
+    form = TipoDocumentoAdminForm(
+        data={
+            "nome": "Documento novo",
+            "obrigatorio": True,
+            "visivel": True,
+            "tem_data_validade": False,
+            "obrigatorio_sme": False,
+        }
+    )
+
+    assert not form.is_valid()
+    assert form.errors["identificador"] == ["Informe o identificador alfanumérico."]
+
+
+def test_admin_form_rejeita_edicao_legada_sem_identificador(tipo_documento):
+    tipo_documento.identificador = None
+    tipo_documento.save(update_fields=["identificador"])
+
+    form = TipoDocumentoAdminForm(
+        instance=tipo_documento,
+        data={
+            "identificador": "",
+            "nome": tipo_documento.nome,
+            "obrigatorio": tipo_documento.obrigatorio,
+            "visivel": tipo_documento.visivel,
+            "tem_data_validade": tipo_documento.tem_data_validade,
+            "obrigatorio_sme": tipo_documento.obrigatorio_sme,
+        },
+    )
+
+    assert not form.is_valid()
+    assert form.errors["identificador"] == ["Informe o identificador alfanumérico."]
+
+
+def test_admin_form_rejeita_edicao_de_tipo_parametrizado_sem_identificador(
+    tipo_documento,
+):
+    form = TipoDocumentoAdminForm(
+        instance=tipo_documento,
+        data={
+            "identificador": "",
+            "nome": tipo_documento.nome,
+            "obrigatorio": tipo_documento.obrigatorio,
+            "visivel": tipo_documento.visivel,
+            "tem_data_validade": tipo_documento.tem_data_validade,
+            "obrigatorio_sme": tipo_documento.obrigatorio_sme,
+        },
+    )
+
+    assert not form.is_valid()
+    assert form.errors["identificador"] == ["Informe o identificador alfanumérico."]
+
+
+def test_admin_form_rejeita_identificador_duplicado(tipo_documento):
+    form = TipoDocumentoAdminForm(
+        data={
+            "identificador": tipo_documento.identificador,
+            "nome": "Outro documento",
+            "obrigatorio": True,
+            "visivel": True,
+            "tem_data_validade": False,
+            "obrigatorio_sme": False,
+        }
+    )
+
+    assert not form.is_valid()
+    assert form.errors["identificador"] == [
+        "Já existe um tipo de documento com este identificador."
+    ]
+
+
+def test_admin_form_rejeita_edicao_para_identificador_duplicado_de_outro_tipo(
+    tipo_documento, tipo_documento_nao_obrigatorio
+):
+    form = TipoDocumentoAdminForm(
+        instance=tipo_documento_nao_obrigatorio,
+        data={
+            "identificador": tipo_documento.identificador,
+            "nome": tipo_documento_nao_obrigatorio.nome,
+            "obrigatorio": tipo_documento_nao_obrigatorio.obrigatorio,
+            "visivel": tipo_documento_nao_obrigatorio.visivel,
+            "tem_data_validade": tipo_documento_nao_obrigatorio.tem_data_validade,
+            "obrigatorio_sme": tipo_documento_nao_obrigatorio.obrigatorio_sme,
+        },
+    )
+
+    assert not form.is_valid()
+    assert form.errors["identificador"] == [
+        "Já existe um tipo de documento com este identificador."
+    ]

--- a/sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipo_documento_serializer.py
+++ b/sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipo_documento_serializer.py
@@ -9,6 +9,7 @@ def test_tipo_documento_serializer(tipo_documento):
     tipo_documento_serializer = TipoDocumentoSerializer(tipo_documento)
 
     assert tipo_documento_serializer.data is not None
+    assert tipo_documento_serializer.data['identificador'] == tipo_documento.identificador
     assert tipo_documento_serializer.data['nome']
     assert tipo_documento_serializer.data['obrigatorio']
     assert tipo_documento_serializer.data['id']

--- a/sme_uniforme_apps/proponentes/upload_validation.py
+++ b/sme_uniforme_apps/proponentes/upload_validation.py
@@ -1,0 +1,35 @@
+import os
+
+PDF_EXTENSIONS = ("pdf",)
+IMAGE_EXTENSIONS = ("jpg", "jpeg", "png")
+
+
+def get_upload_extension(value):
+    if not value:
+        return ""
+
+    if hasattr(value, "name"):
+        return _extension_from_name(value.name)
+
+    if isinstance(value, str):
+        if ";base64," in value:
+            header = value.split(";base64,", 1)[0]
+            return header.split("/")[-1].lower()
+
+        return _extension_from_name(value)
+
+    return ""
+
+
+def validate_upload_extension(value, allowed_extensions, error_message):
+    extension = get_upload_extension(value)
+
+    if extension not in allowed_extensions:
+        raise ValueError(error_message)
+
+    return extension
+
+
+def _extension_from_name(file_name):
+    _, extension = os.path.splitext(file_name or "")
+    return extension.lower().lstrip(".")


### PR DESCRIPTION
## 🎯 Objetivo

Esta PR consolida backend e frontend para adequar o fluxo de proponentes às novas regras de documentos do edital.

O foco da entrega foi:

- parametrizar tipos de documento com identificador técnico no backend;
- endurecer as regras de upload para anexos e fachada;
- remover o comprovante de endereço do ponto de venda das interfaces e do Admin;
- alinhar mensagens, labels e help texts com as regras atuais;
- manter frontend e backend consistentes nos fluxos público e autenticado.

## 🔎 Contexto

- O backend passou a expor `identificador` em `tipos-documento`, com suporte a busca e ordenação.
- O frontend foi mantido compatível com esse retorno, mas continua renderizando os tipos de documento pelo campo `nome`, já que não há uso funcional ou visual para `identificador` nas telas atuais.
- A mudança concentrou-se em comportamento, validação de arquivos e coerência entre Admin, API e interface.

## ✅ O que foi entregue

### Backend

- `TipoDocumento` passou a ter o campo `identificador`, com unicidade e validação para letras, números, hífen e underscore.
- Foi criada a migration `0032_tipodocumento_identificador`.
- O Django Admin de `TipoDocumento` passou a exigir `identificador`, inclusive em edição de registros legados sem preenchimento, e a bloquear duplicidade.
- O backend passou a centralizar validações de extensão em `sme_uniforme_apps/proponentes/upload_validation.py`.
- Uploads de anexos do proponente passaram a aceitar apenas PDF no Admin e na API.
- Uploads de `foto_fachada` passaram a aceitar apenas JPG, JPEG e PNG no Admin e na API.
- `comprovante_endereco` deixou de aparecer no Admin de loja e permaneceu opcional na API, com validação de PDF quando enviado.
- O endpoint `PATCH /proponentes/{uuid}/atualiza-lojas/` passou a validar `comprovante_endereco` antes de salvar o arquivo.
- Labels, help texts e mensagens de erro foram atualizados para refletir as regras vigentes.

### Frontend

- O campo `Comprovante de endereço do ponto de venda` foi removido do cadastro público e da edição logada de lojas.
- `comprovante_endereco` deixou de ser enviado no payload do cadastro público.
- O helper da área logada passou a tratar `comprovante_endereco` de forma defensiva apenas quando ainda vier como array, preservando compatibilidade com dados legados.
- As regras de upload foram centralizadas em um helper compartilhado.
- A fachada passou a aceitar somente `.png`, `.jpg` e `.jpeg`.
- Os demais anexos passaram a aceitar somente `.pdf`.
- Os textos auxiliares dos campos de upload foram atualizados para refletir formatos permitidos e limite de 5 MB.
- O payload de upload foi padronizado para envio do campo `arquivo` com `e[0].arquivo`.
- As telas pública e autenticada passaram a reutilizar a mesma regra de validação, reduzindo divergência entre fluxos.

## 📡 Impacto funcional

- Tipos de documento agora possuem identificador técnico padronizado e pesquisável no backend.
- Registros legados sem identificador continuam existindo, mas não podem mais ser salvos pelo Admin sem correção.
- O comprovante de endereço do ponto de venda deixa de aparecer nas interfaces do frontend e no Admin.
- O comprovante de endereço continua opcional na API de lojas, mas, quando enviado, deve ser PDF.
- Documentos anexos passam a rejeitar qualquer arquivo diferente de PDF.
- A foto da fachada passa a rejeitar PDF e qualquer formato fora de JPG, JPEG e PNG.
- Backend e frontend passam a comunicar as mesmas regras por meio de validação e textos de apoio consistentes.

## 🖥️ Fluxos impactados

- Admin de `TipoDocumento`
- Admin e inline de `Loja`
- API de `tipos-documento`
- `PATCH /lojas/{uuid}/`
- `PATCH /proponentes/{uuid}/atualiza-lojas/`
- `/cadastro`
- Aba `Anexos` do cadastro público
- `/adm-fornecedor/dados-empresa`
- `/adm-fornecedor/anexos`

## 🧪 Testes automatizados

### Backend nos testes

Cobertura adicionada e ajustada para validar:

- exposição, busca, ordenação, obrigatoriedade e unicidade de `identificador` em `TipoDocumento`;
- labels, help texts e regras de aceite de anexos do proponente;
- remoção de `comprovante_endereco` do Admin de loja;
- configuração e validação de uploads de `foto_fachada` e `comprovante_endereco` em forms, serializers e endpoints;
- sucesso e rejeição no endpoint de atualização de lojas do proponente conforme o tipo de arquivo enviado.

Arquivos de teste impactados:

- `sme_uniforme_apps/proponentes/tests/conftest.py`
- `sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipo_documento_model.py`
- `sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipo_documento_serializer.py`
- `sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py`
- `sme_uniforme_apps/proponentes/tests/test_loja/test_model.py`
- `sme_uniforme_apps/proponentes/tests/test_loja/test_serializers.py`
- `sme_uniforme_apps/proponentes/tests/test_loja/test_endpoint.py`
- `sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py`

Comando executado:

```bash
docker compose -f docker-compose-dev.yml exec -T web pytest -q \
  sme_uniforme_apps/proponentes/tests/test_tipo_documento \
  sme_uniforme_apps/proponentes/tests/test_anexo \
  sme_uniforme_apps/proponentes/tests/test_loja \
  sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py
```

Resultado:

- `56 passed`
- `0 failed`

### Frontend nos testes

Cobertura adicionada e ajustada para validar:

- regra centralizada de aceite de arquivos;
- comportamento do componente compartilhado de upload;
- remoção do comprovante de endereço no cadastro público;
- remoção do comprovante de endereço na edição logada;
- atualização do snapshot do componente de upload.

Arquivos de teste impactados:

- `src/helpers/fileUpload.test.js`
- `src/components/Input/FileUpload.test.js`
- `src/components/Input/__snapshots__/FileUpload.test.js.snap`
- `src/screens/CadastroEmpresa/LojaFisica.test.js`
- `src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.test.jsx`

Comando executado:

```bash
docker compose -f docker-compose-dev.yml exec frontend npm test -- --runTestsByPath src/helpers/fileUpload.test.js src/components/Input/FileUpload.test.js src/screens/CadastroEmpresa/LojaFisica.test.js src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.test.jsx --watchAll=false
```

Resultado:

- `4` suites passaram
- `7` testes passaram
- `1` snapshot passou

## 📋 Checklist funcional

- Validar no Admin que `TipoDocumento` exige `identificador` e aceita busca por esse campo.
- Validar no Admin e na API que anexos do proponente aceitam apenas PDF.
- Validar no Admin e na API que a fachada aceita apenas PNG, JPG e JPEG.
- Validar que `comprovante_endereco` não aparece no Admin nem nas telas de cadastro e edição de loja.
- Validar que o endpoint de atualização de lojas aceita ausência de comprovante e rejeita arquivo não PDF quando ele é enviado.
- Validar em `/adm-fornecedor/anexos` e no fluxo público que as regras de upload permanecem idênticas.

## 📌 Resumo

- Esta PR alinha backend e frontend ao novo edital no fluxo de documentos do proponente.
- O impacto principal está na parametrização técnica dos tipos de documento, na remoção do comprovante de endereço da loja e no endurecimento das regras de upload.
- A implementação foi centralizada para reduzir divergência entre Admin, API, cadastro público e área logada.
