### PR TITLE
Feature(148711): Validação Análise IA - Anexos

### DIFF
--- a/sme_uniforme_apps/proponentes/admin.py
+++ b/sme_uniforme_apps/proponentes/admin.py
@@ -5,7 +5,10 @@ from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
 from django.db.models import Count
 from django.http import HttpResponse
+from django.utils import timezone
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+from django.utils.text import slugify
 from django.contrib import messages
 from openpyxl import Workbook
 from openpyxl.writer.excel import save_virtual_workbook
@@ -30,7 +33,115 @@ class LojasInLine(admin.StackedInline):
 class AnexosInLine(admin.TabularInline):
     form = AnexoForm
     model = Anexo
-    extra = 1  # Quantidade de linhas que serão exibidas.
+    extra = 0
+    fields = (
+        'tipo_documento',
+        'arquivo',
+        'data_validade',
+        'status_ia_info',
+        'justificativa_ia_info',
+        'status',
+        'justificativa',
+        'ultima_alteracao_admin_info',
+    )
+    readonly_fields = (
+        'status_ia_info',
+        'justificativa_ia_info',
+        'ultima_alteracao_admin_info',
+    )
+
+    class Media:
+        css = {'all': ('proponentes/css/anexos-inline.css',)}
+        js = ()
+
+    @staticmethod
+    def _nome_usuario(usuario):
+        nome_completo = ''
+        if hasattr(usuario, 'get_full_name'):
+            nome_completo = usuario.get_full_name().strip()
+
+        return nome_completo or getattr(usuario, 'email', '') or str(usuario)
+
+    def _resolve_ultima_alteracao(self, obj):
+        usuario = obj.ultima_alteracao_admin_por
+        data = obj.ultima_alteracao_admin_em
+
+        if usuario and data:
+            return usuario, data
+
+        historico = (
+            obj.historico.exclude(actor=None)
+            .select_related('actor')
+            .order_by('-timestamp')
+            .first()
+        )
+        if historico:
+            return historico.actor, historico.timestamp
+
+        return None, None
+
+    def status_ia_info(self, obj):
+        status_ia = obj.status_ia if obj and obj.status_ia else ''
+        status_ia_exibicao = (
+            Anexo.STATUS_NOMES.get(status_ia, status_ia)
+            if status_ia
+            else 'Sem análise de IA.'
+        )
+        classe = 'sem-analise'
+        if status_ia:
+            classe = slugify(status_ia).replace('_', '-') or 'status-ia'
+
+        return format_html(
+            '<span class="anexo-status-ia anexo-status-ia-{}">{}</span>',
+            classe,
+            status_ia_exibicao,
+        )
+
+    status_ia_info.short_description = 'Status IA'
+
+    def justificativa_ia_info(self, obj):
+        justificativa_ia = obj.justificativa_ia if obj and obj.justificativa_ia else ''
+        justificativa_data = justificativa_ia
+
+        if not justificativa_ia:
+            return format_html(
+                '<div class="anexo-ia-justificativa anexo-ia-justificativa-vazia" data-justificativa-ia=""></div>'
+            )
+
+        resumo = justificativa_ia
+        if len(resumo) > 42:
+            resumo = '{}...'.format(resumo[:42])
+
+        return format_html(
+            (
+                '<details class="anexo-ia-detalhe">'
+                '<summary title="{}">{}</summary>'
+                '<div class="anexo-ia-justificativa" data-justificativa-ia="{}">{}</div>'
+                '</details>'
+            ),
+            justificativa_ia,
+            resumo,
+            justificativa_data,
+            justificativa_ia,
+        )
+
+    justificativa_ia_info.short_description = 'Justificativa IA'
+
+    def ultima_alteracao_admin_info(self, obj):
+        if not obj or not obj.pk:
+            return 'Nenhuma alteração registrada.'
+
+        usuario, data = self._resolve_ultima_alteracao(obj)
+        if not usuario or not data:
+            return 'Nenhuma alteração registrada.'
+
+        return format_html(
+            '<div class="anexo-auditoria"><strong>{}</strong><span>{}</span></div>',
+            self._nome_usuario(usuario),
+            timezone.localtime(data).strftime('%d/%m/%Y'),
+        )
+
+    ultima_alteracao_admin_info.short_description = 'Auditoria'
 
 
 class ExportXlsxMixin:
@@ -200,6 +311,23 @@ class ProponenteAdmin(admin.ModelAdmin, ExportXlsxMixin):
             if 'cria_usuario_proponente_sem_usuario' in actions:
                 del actions['cria_usuario_proponente_sem_usuario']
         return actions
+
+    def save_formset(self, request, form, formset, change):
+        if formset.model is not Anexo:
+            return super().save_formset(request, form, formset, change)
+
+        instances = formset.save(commit=False)
+
+        for deleted_object in formset.deleted_objects:
+            deleted_object.delete()
+
+        for instance in instances:
+            instance.copiar_justificativa_ia_para_admin()
+            instance.ultima_alteracao_admin_por = request.user
+            instance.ultima_alteracao_admin_em = timezone.now()
+            instance.save()
+
+        formset.save_m2m()
 
     actions = [
         'verifica_bloqueio_cnpj',

--- a/sme_uniforme_apps/proponentes/api/serializers/anexo_serializer.py
+++ b/sme_uniforme_apps/proponentes/api/serializers/anexo_serializer.py
@@ -15,7 +15,18 @@ class AnexoSerializer(ModelSerializer):
 
     class Meta:
         model = Anexo
-        fields = '__all__'
+        fields = (
+            "id",
+            "criado_em",
+            "alterado_em",
+            "uuid",
+            "proponente",
+            "arquivo",
+            "data_validade",
+            "status",
+            "justificativa",
+            "tipo_documento",
+        )
 
 
 class AnexoCreateSerializer(serializers.ModelSerializer):
@@ -43,4 +54,16 @@ class AnexoCreateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Anexo
-        exclude = ('id',)
+        exclude = (
+            "id",
+            "status_ia",
+            "justificativa_ia",
+            "ultima_alteracao_admin_por",
+            "ultima_alteracao_admin_em",
+        )
+        extra_kwargs = {
+            'arquivo': {
+                'label': 'Documento do proponente',
+                'help_text': 'Envie apenas arquivos PDF.',
+            }
+        }

--- a/sme_uniforme_apps/proponentes/migrations/0033_anexo_campos_ia_e_auditoria.py
+++ b/sme_uniforme_apps/proponentes/migrations/0033_anexo_campos_ia_e_auditoria.py
@@ -1,0 +1,76 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("proponentes", "0032_tipodocumento_identificador"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="anexo",
+            name="justificativa_ia",
+            field=models.TextField(
+                blank=True, null=True, verbose_name="Justificativa IA"
+            ),
+        ),
+        migrations.AddField(
+            model_name="anexo",
+            name="status_ia",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("APROVADO", "Aprovado"),
+                    ("REPROVADO", "Reprovado"),
+                    ("PENDENTE", "Pendente"),
+                    ("VENCIDO", "Vencido"),
+                ],
+                max_length=15,
+                null=True,
+                verbose_name="Status IA",
+            ),
+        ),
+        migrations.AddField(
+            model_name="anexo",
+            name="ultima_alteracao_admin_em",
+            field=models.DateTimeField(blank=True, editable=False, null=True),
+        ),
+        migrations.AddField(
+            model_name="anexo",
+            name="ultima_alteracao_admin_por",
+            field=models.ForeignKey(
+                blank=True,
+                editable=False,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="anexos_alterados_no_admin",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="anexo",
+            name="justificativa",
+            field=models.TextField(
+                blank=True, null=True, verbose_name="Justificativa Admin"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="anexo",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("APROVADO", "Aprovado"),
+                    ("REPROVADO", "Reprovado"),
+                    ("PENDENTE", "Pendente"),
+                    ("VENCIDO", "Vencido"),
+                ],
+                default="PENDENTE",
+                max_length=15,
+                verbose_name="Status Admin",
+            ),
+        ),
+    ]

--- a/sme_uniforme_apps/proponentes/migrations/0034_altera_status_ia_aberto.py
+++ b/sme_uniforme_apps/proponentes/migrations/0034_altera_status_ia_aberto.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("proponentes", "0033_anexo_campos_ia_e_auditoria"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="anexo",
+            name="status_ia",
+            field=models.CharField(
+                blank=True, max_length=255, null=True, verbose_name="Status IA"
+            ),
+        ),
+    ]

--- a/sme_uniforme_apps/proponentes/models/anexo.py
+++ b/sme_uniforme_apps/proponentes/models/anexo.py
@@ -1,5 +1,6 @@
 from auditlog.models import AuditlogHistoryField
 from auditlog.registry import auditlog
+from django.conf import settings
 from django.db import models
 
 from sme_uniforme_apps.core.models_abstracts import ModeloBase
@@ -27,6 +28,7 @@ class Anexo(ModeloBase):
         (STATUS_PENDENTE, STATUS_NOMES[STATUS_PENDENTE]),
         (STATUS_VENCIDO, STATUS_NOMES[STATUS_VENCIDO]),
     )
+    STATUS_COM_COPIA_DA_IA = (STATUS_REPROVADO, STATUS_VENCIDO)
 
     historico = AuditlogHistoryField()
 
@@ -37,13 +39,28 @@ class Anexo(ModeloBase):
     data_validade = models.DateField(null=True, blank=True)
 
     status = models.CharField(
-        'status',
+        'Status Admin',
         max_length=15,
         choices=STATUS_CHOICES,
         default=STATUS_PENDENTE
     )
 
-    justificativa = models.TextField('Justificativa', blank=True, null=True)
+    justificativa = models.TextField('Justificativa Admin', blank=True, null=True)
+
+    status_ia = models.CharField('Status IA', max_length=255, blank=True, null=True)
+
+    justificativa_ia = models.TextField('Justificativa IA', blank=True, null=True)
+
+    ultima_alteracao_admin_por = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        editable=False,
+        related_name='anexos_alterados_no_admin'
+    )
+
+    ultima_alteracao_admin_em = models.DateTimeField(blank=True, null=True, editable=False)
 
     tipo_documento = models.ForeignKey(
         TipoDocumento,
@@ -63,6 +80,14 @@ class Anexo(ModeloBase):
             "data_validade": self.data_validade,
             "uuid": self.uuid
         }
+
+    def copiar_justificativa_ia_para_admin(self, sobrescrever=False):
+        if (
+            self.status in self.STATUS_COM_COPIA_DA_IA
+            and self.justificativa_ia
+            and (sobrescrever or not self.justificativa)
+        ):
+            self.justificativa = self.justificativa_ia
 
     class Meta:
         verbose_name = "Anexo"

--- a/sme_uniforme_apps/proponentes/models/forms.py
+++ b/sme_uniforme_apps/proponentes/models/forms.py
@@ -8,8 +8,129 @@ class AnexoForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(AnexoForm, self).__init__(*args, **kwargs)
 
-        self.fields['tipo_documento'].required = True
+        self.fields["tipo_documento"].required = True
+        self.fields["arquivo"].label = "Documento do proponente"
+        self.fields["arquivo"].help_text = "Envie apenas arquivos PDF."
+        self.fields["tipo_documento"].widget.attrs["style"] = "width: 220px;"
+        self.fields["tipo_documento"].widget.attrs[
+            "onchange"
+        ] = "this.title=this.options[this.selectedIndex] ? this.options[this.selectedIndex].text : '';"
+        if self.instance and self.instance.tipo_documento_id:
+            self.fields["tipo_documento"].widget.attrs[
+                "title"
+            ] = self.instance.tipo_documento.nome
+        self.fields["status"].label = "Status Admin"
+        self.fields["justificativa"].label = "Justificativa Admin"
+        self.fields["status"].initial = self.instance.status or Anexo.STATUS_PENDENTE
+        self.fields["status"].widget.attrs["style"] = "width: 140px;"
+        self.fields["status"].widget.attrs["onchange"] = (
+            "var inline=this.closest('.dynamic-anexos');"
+            "var justificativa=inline&&inline.querySelector('textarea[id$=\"-justificativa\"]');"
+            "var justificativaIA=inline&&inline.querySelector('.anexo-ia-justificativa');"
+            "if((this.value==='REPROVADO'||this.value==='VENCIDO')&&justificativa&&!justificativa.value.trim()&&justificativaIA){"
+            "justificativa.value=(justificativaIA.getAttribute('data-justificativa-ia')||'').trim();"
+            "}"
+        )
+        self.fields["justificativa"].widget.attrs["rows"] = 3
+        self.fields["justificativa"].widget.attrs["style"] = "width: 340px;"
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        self.instance.status = cleaned_data.get("status")
+        self.instance.justificativa = cleaned_data.get("justificativa")
+        self.instance.copiar_justificativa_ia_para_admin()
+        cleaned_data["justificativa"] = self.instance.justificativa
+
+        return cleaned_data
+
+    def clean_arquivo(self):
+        arquivo = self.cleaned_data.get("arquivo")
+
+        if not arquivo or "arquivo" not in self.changed_data:
+            return arquivo
+
+        try:
+            validate_upload_extension(
+                arquivo,
+                PDF_EXTENSIONS,
+                "Envie o documento do proponente em PDF.",
+            )
+        except ValueError as exc:
+            raise forms.ValidationError(str(exc))
+
+        return arquivo
 
     class Meta:
         model = Anexo
-        fields = '__all__'
+        exclude = (
+            "status_ia",
+            "justificativa_ia",
+            "ultima_alteracao_admin_por",
+            "ultima_alteracao_admin_em",
+        )
+
+
+class LojaAdminForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super(LojaAdminForm, self).__init__(*args, **kwargs)
+
+        self.fields["foto_fachada"].label = "Foto da fachada da loja"
+        self.fields["foto_fachada"].help_text = (
+            "Envie apenas arquivos JPG, JPEG ou PNG."
+        )
+
+    def clean_foto_fachada(self):
+        foto_fachada = self.cleaned_data.get("foto_fachada")
+
+        if not foto_fachada or "foto_fachada" not in self.changed_data:
+            return foto_fachada
+
+        try:
+            validate_upload_extension(
+                foto_fachada,
+                IMAGE_EXTENSIONS,
+                "Envie a foto da fachada em JPG, JPEG ou PNG.",
+            )
+        except ValueError as exc:
+            raise forms.ValidationError(str(exc))
+
+        return foto_fachada
+
+    class Meta:
+        model = Loja
+        fields = "__all__"
+
+
+class TipoDocumentoAdminForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super(TipoDocumentoAdminForm, self).__init__(*args, **kwargs)
+
+        self.fields["identificador"].required = True
+        self.fields["identificador"].error_messages[
+            "required"
+        ] = "Informe o identificador alfanumérico."
+
+    def clean_identificador(self):
+        identificador = (self.cleaned_data.get("identificador") or "").strip() or None
+
+        if not identificador:
+            raise forms.ValidationError("Informe o identificador alfanumérico.")
+
+        if (
+            identificador
+            and TipoDocumento.objects.exclude(pk=self.instance.pk)
+            .filter(identificador=identificador)
+            .exists()
+        ):
+            raise forms.ValidationError(
+                "Já existe um tipo de documento com este identificador."
+            )
+
+        return identificador
+
+    class Meta:
+        model = TipoDocumento
+        fields = "__all__"

--- a/sme_uniforme_apps/proponentes/static/proponentes/css/anexos-inline.css
+++ b/sme_uniforme_apps/proponentes/static/proponentes/css/anexos-inline.css
@@ -1,0 +1,174 @@
+#anexos-group table {
+    table-layout: fixed;
+}
+
+#anexos-group td.original,
+#anexos-group td.field-tipo_documento,
+#anexos-group td.field-arquivo,
+#anexos-group td.field-data_validade,
+#anexos-group td.field-status_ia_info,
+#anexos-group td.field-justificativa_ia_info,
+#anexos-group td.field-status,
+#anexos-group td.field-justificativa,
+#anexos-group td.field-ultima_alteracao_admin_info,
+#anexos-group th.original,
+#anexos-group th.column-tipo_documento,
+#anexos-group th.column-arquivo,
+#anexos-group th.column-data_validade,
+#anexos-group th.column-status_ia_info,
+#anexos-group th.column-justificativa_ia_info,
+#anexos-group th.column-status,
+#anexos-group th.column-justificativa,
+#anexos-group th.column-ultima_alteracao_admin_info {
+    vertical-align: top !important;
+}
+
+#anexos-group td.original p,
+#anexos-group td.field-arquivo .file-upload,
+#anexos-group td.field-data_validade p,
+#anexos-group td.field-justificativa_ia_info details,
+#anexos-group td.field-tipo_documento .related-widget-wrapper {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+#anexos-group td.field-tipo_documento,
+#anexos-group th.column-tipo_documento {
+    width: 220px;
+}
+
+#anexos-group td.field-arquivo,
+#anexos-group th.column-arquivo {
+    width: 180px;
+}
+
+#anexos-group td.field-arquivo {
+    padding-top: 2px !important;
+}
+
+#anexos-group td.field-data_validade,
+#anexos-group th.column-data_validade {
+    width: 105px;
+}
+
+#anexos-group td.field-status_ia_info,
+#anexos-group th.column-status_ia_info {
+    width: 110px;
+}
+
+#anexos-group td.field-justificativa_ia_info,
+#anexos-group th.column-justificativa_ia_info {
+    width: 200px;
+}
+
+#anexos-group td.field-status,
+#anexos-group th.column-status {
+    width: 145px;
+}
+
+#anexos-group td.field-justificativa,
+#anexos-group th.column-justificativa {
+    width: 360px;
+}
+
+#anexos-group td.field-ultima_alteracao_admin_info,
+#anexos-group th.column-ultima_alteracao_admin_info {
+    width: 170px;
+}
+
+#anexos-group td.field-tipo_documento select,
+#anexos-group td.field-arquivo input[type="file"],
+#anexos-group td.field-status select,
+#anexos-group td.field-justificativa textarea,
+#anexos-group td.field-data_validade input[type="text"] {
+    max-width: 100%;
+}
+
+#anexos-group td.field-tipo_documento .related-widget-wrapper {
+    display: inline-flex;
+    align-items: flex-start;
+    gap: 4px;
+    max-width: 220px;
+}
+
+#anexos-group td.field-tipo_documento select {
+    width: 220px !important;
+    max-width: 220px !important;
+}
+
+#anexos-group td.field-arquivo .file-upload,
+#anexos-group td.field-status_ia_info .readonly,
+#anexos-group td.field-justificativa_ia_info .readonly,
+#anexos-group td.field-ultima_alteracao_admin_info .readonly {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+}
+
+#anexos-group td.field-arquivo .file-upload {
+    flex-direction: column;
+}
+
+#anexos-group td.field-status select,
+#anexos-group td.field-justificativa textarea,
+#anexos-group td.field-data_validade p {
+    margin-top: 0;
+}
+
+#anexos-group .readonly,
+#anexos-group .anexo-ia-justificativa,
+#anexos-group .anexo-auditoria {
+    white-space: normal;
+    word-break: break-word;
+}
+
+#anexos-group .anexo-status-ia {
+    display: inline-block;
+    padding: 3px 8px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.3;
+    white-space: nowrap;
+}
+
+#anexos-group .anexo-status-ia-aprovado {
+    background: #e7f6eb;
+    color: #22603a;
+}
+
+#anexos-group .anexo-status-ia-reprovado,
+#anexos-group .anexo-status-ia-vencido {
+    background: #fbe9e7;
+    color: #8a2d1d;
+}
+
+#anexos-group .anexo-status-ia-pendente,
+#anexos-group .anexo-status-ia-sem-analise {
+    background: #edf2f7;
+    color: #465a69;
+}
+
+#anexos-group .anexo-ia-detalhe {
+    max-width: 200px;
+}
+
+#anexos-group .anexo-ia-detalhe summary {
+    cursor: pointer;
+    color: #0b57a3;
+}
+
+#anexos-group .anexo-ia-justificativa {
+    margin-top: 6px;
+}
+
+#anexos-group .anexo-ia-justificativa-vazia {
+    min-height: 18px;
+}
+
+#anexos-group .anexo-auditoria {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+}

--- a/sme_uniforme_apps/proponentes/tests/test_anexo/test_admin.py
+++ b/sme_uniforme_apps/proponentes/tests/test_anexo/test_admin.py
@@ -1,0 +1,176 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.forms.models import inlineformset_factory
+from django.test import RequestFactory
+from django.urls import reverse
+from django.utils import timezone
+
+from ...admin import AnexosInLine, ProponenteAdmin
+from ...models import Anexo, Proponente
+from ...models.forms import AnexoForm
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+@pytest.fixture
+def admin_user():
+    usuario = User.objects.create_superuser(email="gestor@teste.com", password="123456")
+    usuario.first_name = "Gestor"
+    usuario.last_name = "Contrato"
+    usuario.save()
+    return usuario
+
+
+@pytest.fixture
+def admin_client_logado(client, admin_user):
+    client.force_login(admin_user)
+    return client
+
+
+def test_tela_admin_do_proponente_exibe_campos_ia_e_admin(admin_client_logado, anexo):
+    response = admin_client_logado.get(
+        reverse("admin:proponentes_proponente_change", args=[anexo.proponente.pk])
+    )
+
+    assert response.status_code == 200
+    conteudo = response.content.decode("utf-8")
+    assert "Status IA" in conteudo
+    assert "Justificativa IA" in conteudo
+    assert "Status Admin" in conteudo
+    assert "Justificativa Admin" in conteudo
+    assert 'name="anexos-0-status"' in conteudo
+    assert 'name="anexos-0-status_ia"' not in conteudo
+    assert 'name="anexos-0-justificativa_ia"' not in conteudo
+    assert "proponentes/js/anexos-inline.js" not in conteudo
+    assert "anexo-ia-justificativa" in conteudo
+    assert "querySelector" in conteudo
+
+
+def test_save_formset_do_admin_copia_justificativa_e_registra_auditoria(
+    admin_user,
+    proponente,
+    anexo,
+):
+    site = AdminSite()
+    model_admin = ProponenteAdmin(Proponente, site)
+    formset_class = inlineformset_factory(
+        Proponente,
+        Anexo,
+        form=AnexoForm,
+        extra=0,
+        can_delete=True,
+    )
+    prefix = formset_class.get_default_prefix()
+    anexo.status_ia = Anexo.STATUS_REPROVADO
+    anexo.justificativa_ia = "Documento divergente segundo a IA."
+    anexo.save(update_fields=["status_ia", "justificativa_ia"])
+    data = {
+        f"{prefix}-TOTAL_FORMS": "1",
+        f"{prefix}-INITIAL_FORMS": "1",
+        f"{prefix}-MIN_NUM_FORMS": "0",
+        f"{prefix}-MAX_NUM_FORMS": "1000",
+        f"{prefix}-0-id": str(anexo.id),
+        f"{prefix}-0-proponente": str(proponente.id),
+        f"{prefix}-0-tipo_documento": str(anexo.tipo_documento_id),
+        f"{prefix}-0-data_validade": "",
+        f"{prefix}-0-status": Anexo.STATUS_REPROVADO,
+        f"{prefix}-0-justificativa": "",
+    }
+    formset = formset_class(data=data, instance=proponente, prefix=prefix)
+
+    assert formset.is_valid(), formset.errors
+
+    request = RequestFactory().post("/")
+    request.user = admin_user
+
+    model_admin.save_formset(request, None, formset, change=True)
+
+    anexo.refresh_from_db()
+
+    assert anexo.justificativa == "Documento divergente segundo a IA."
+    assert anexo.ultima_alteracao_admin_por == admin_user
+    assert anexo.ultima_alteracao_admin_em is not None
+
+
+def test_inline_exibe_informacao_de_auditoria_no_admin(
+    admin_client_logado, admin_user, anexo
+):
+    anexo.ultima_alteracao_admin_por = admin_user
+    anexo.ultima_alteracao_admin_em = timezone.now()
+    anexo.save(
+        update_fields=["ultima_alteracao_admin_por", "ultima_alteracao_admin_em"]
+    )
+
+    response = admin_client_logado.get(
+        reverse("admin:proponentes_proponente_change", args=[anexo.proponente.pk])
+    )
+
+    assert response.status_code == 200
+    conteudo = response.content.decode("utf-8")
+    assert "anexo-auditoria" in conteudo
+    assert "Gestor Contrato" in conteudo
+    assert (
+        timezone.localtime(anexo.ultima_alteracao_admin_em).strftime("%d/%m/%Y")
+        in conteudo
+    )
+
+
+def test_inline_monta_texto_de_auditoria_com_nome_e_data(admin_user, anexo):
+    inline = AnexosInLine(Proponente, AdminSite())
+    anexo.ultima_alteracao_admin_por = admin_user
+    anexo.ultima_alteracao_admin_em = timezone.now()
+
+    texto = inline.ultima_alteracao_admin_info(anexo)
+
+    assert "Gestor Contrato" in texto
+    assert (
+        timezone.localtime(anexo.ultima_alteracao_admin_em).strftime("%d/%m/%Y")
+        in texto
+    )
+
+
+def test_inline_exibe_justificativa_ia_em_bloco_readonly_com_hook_js(anexo):
+    inline = AnexosInLine(Proponente, AdminSite())
+    anexo.status_ia = Anexo.STATUS_REPROVADO
+    anexo.justificativa_ia = "Documento divergente segundo a IA."
+
+    html = inline.justificativa_ia_info(anexo)
+
+    assert "<details" in html
+    assert "Documento divergente segundo a IA." in html
+    assert "anexo-ia-justificativa" in html
+    assert 'data-justificativa-ia="Documento divergente segundo a IA."' in html
+
+
+def test_inline_deixa_justificativa_ia_vazia_quando_nao_ha_texto(anexo):
+    inline = AnexosInLine(Proponente, AdminSite())
+    anexo.justificativa_ia = ""
+
+    html = inline.justificativa_ia_info(anexo)
+
+    assert "Sem justificativa de IA." not in html
+    assert "<details" not in html
+    assert 'data-justificativa-ia=""' in html
+
+
+def test_inline_exibe_status_ia_em_formato_compacto(anexo):
+    inline = AnexosInLine(Proponente, AdminSite())
+    anexo.status_ia = Anexo.STATUS_REPROVADO
+
+    html = inline.status_ia_info(anexo)
+
+    assert "anexo-status-ia" in html
+    assert "Reprovado" in html
+
+
+def test_inline_exibe_status_ia_desconhecido_sem_choices_fixos(anexo):
+    inline = AnexosInLine(Proponente, AdminSite())
+    anexo.status_ia = "EM_ANALISE_EXTERNA_MANUAL"
+
+    html = inline.status_ia_info(anexo)
+
+    assert "EM_ANALISE_EXTERNA_MANUAL" in html
+    assert "anexo-status-ia-em-analise-externa-manual" in html

--- a/sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py
+++ b/sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py
@@ -30,3 +30,95 @@ def test_anexo_api_delete_model(delete):
 
 def test_anexo_api_create_model_not_exists(client, delete):
     assert not Anexo.objects.exists()
+
+
+def test_anexo_form_configura_label_e_help_text():
+    form = AnexoForm()
+
+    assert form.fields["arquivo"].label == "Documento do proponente"
+    assert form.fields["arquivo"].help_text == "Envie apenas arquivos PDF."
+    assert form.fields["status"].label == "Status Admin"
+    assert form.fields["justificativa"].label == "Justificativa Admin"
+    assert form.fields["status"].initial == Anexo.STATUS_PENDENTE
+    assert form.fields["tipo_documento"].widget.attrs["style"] == "width: 220px;"
+    assert form.fields["justificativa"].widget.attrs["style"] == "width: 340px;"
+    assert "status_ia" not in form.fields
+    assert "justificativa_ia" not in form.fields
+
+
+def test_anexo_form_define_title_do_tipo_documento_quando_instancia_tem_valor(
+    tipo_documento,
+):
+    tipo_documento.nome = "Documento muito grande para validar o title do select"
+    form = AnexoForm(instance=Anexo(tipo_documento=tipo_documento))
+
+    assert form.fields["tipo_documento"].widget.attrs["title"] == tipo_documento.nome
+
+
+def test_anexo_create_serializer_configura_label_e_help_text():
+    serializer = AnexoCreateSerializer()
+
+    assert serializer.fields["arquivo"].label == "Documento do proponente"
+    assert serializer.fields["arquivo"].help_text == "Envie apenas arquivos PDF."
+
+
+def test_anexo_form_aceita_pdf(tipo_documento):
+    form = AnexoForm(
+        data={
+            "tipo_documento": tipo_documento.id,
+            "status": Anexo.STATUS_PENDENTE,
+        },
+        files={"arquivo": create_uploaded_file("anexo.pdf")},
+    )
+
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.parametrize("status_admin", [Anexo.STATUS_REPROVADO, Anexo.STATUS_VENCIDO])
+def test_anexo_form_copia_justificativa_ia_para_admin(tipo_documento, status_admin):
+    anexo = Anexo(
+        tipo_documento=tipo_documento,
+        status_ia=Anexo.STATUS_REPROVADO,
+        justificativa_ia="Documento divergente segundo a IA.",
+    )
+    form = AnexoForm(
+        data={
+            "tipo_documento": tipo_documento.id,
+            "status": status_admin,
+            "justificativa": "",
+        },
+        files={"arquivo": create_uploaded_file("anexo.pdf")},
+        instance=anexo,
+    )
+
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["justificativa"] == "Documento divergente segundo a IA."
+
+
+@pytest.mark.parametrize("file_name", ["anexo.jpg", "anexo.png", "anexo.txt"])
+def test_anexo_form_rejeita_arquivo_nao_pdf(tipo_documento, file_name):
+    form = AnexoForm(
+        data={
+            "tipo_documento": tipo_documento.id,
+            "status": Anexo.STATUS_PENDENTE,
+        },
+        files={"arquivo": create_uploaded_file(file_name)},
+    )
+
+    assert not form.is_valid()
+    assert form.errors["arquivo"] == ["Envie o documento do proponente em PDF."]
+
+
+@pytest.mark.parametrize(
+    "arquivo_invalido", [ARQUIVO_JPG_BASE64, ARQUIVO_PNG_BASE64, ARQUIVO_TXT_BASE64]
+)
+def test_anexo_api_rejeita_arquivo_nao_pdf(client, payload_anexo, arquivo_invalido):
+    payload_anexo["arquivo"] = arquivo_invalido
+
+    response = client.post(
+        "/anexos/", data=json.dumps(payload_anexo), content_type="application/json"
+    )
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result["arquivo"] == ["Envie o documento do proponente em PDF."]


### PR DESCRIPTION
## 🌿 Contexto

Preparar o backend e o Django Admin para armazenar, exibir e validar o retorno de análise de IA dos anexos de proponentes.

## 🎯 Objetivo

- Permitir que o gestor visualize no Django Admin os dados retornados pela análise de IA dos anexos.
- Separar claramente o resultado da IA da decisão administrativa do gestor.
- Registrar auditoria da validação feita no admin.
- Deixar a estrutura pronta para receber status vindos de uma ferramenta externa, sem depender de `choices` fixos para `Status IA`.

## ✨ O Que Foi Implementado

- O modelo `Anexo` passou a armazenar os campos `status_ia`, `justificativa_ia`, `ultima_alteracao_admin_por` e `ultima_alteracao_admin_em`.
- Os campos já existentes do fluxo administrativo foram semantizados como decisão do gestor: `status` representa `Status Admin` e `justificativa` representa `Justificativa Admin`.
- O campo `status_ia` foi aberto para receber qualquer valor textual vindo de integração externa, sem `choices` fixos.
- O Django Admin passou a exibir `Status IA`, `Justificativa IA`, `Status Admin`, `Justificativa Admin` e a auditoria da última alteração no inline de anexos do proponente.
- A justificativa da IA é copiada automaticamente para a justificativa administrativa quando o gestor marca o anexo como `Reprovado` ou `Vencido` e o campo administrativo ainda está vazio.
- A exibição da `Justificativa IA` foi tratada para ficar vazia quando não houver conteúdo, sem sugerir texto padrão ao usuário.
- O `Status IA` no admin continua exibindo rótulos amigáveis para os status conhecidos do sistema (`Aprovado`, `Reprovado`, `Pendente`, `Vencido`), mas também mostra corretamente qualquer status novo/desconhecido recebido da ferramenta externa.
- O inline do admin recebeu ajustes visuais pontuais via CSS próprio para melhorar largura, alinhamento, leitura da justificativa e comportamento do `tipo_documento` com nomes longos.
- O CSS da visualização foi isolado ao grupo de anexos do inline (`#anexos-group`) para evitar impacto em outras páginas do Django Admin.

## 🧩 Principais Decisões Técnicas

- `status_ia` não depende mais de `choices`; isso evita novo deploy/migration sempre que a ferramenta externa introduzir um status diferente.
- A renderização do `Status IA` no admin usa fallback: se o valor existir em `Anexo.STATUS_NOMES`, o admin mostra o nome amigável; caso contrário, mostra o valor bruto recebido.
- O `AnexoCreateSerializer` continua excluindo os campos de IA e auditoria do fluxo público atual, preservando o contrato atual da API enquanto a integração externa ainda não existe.
- A auditoria do admin usa os campos explícitos `ultima_alteracao_admin_por` e `ultima_alteracao_admin_em`, com fallback para o histórico do `auditlog` quando necessário.

## 🧪 Testes

### ✅ Execução realizada

- Comando executado:
  `docker compose -f docker-compose-dev.yml exec web pytest sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py sme_uniforme_apps/proponentes/tests/test_anexo/test_admin.py -q`
- Resultado validado no estado atual:
  `24 passed`

### 🆕 Testes criados

Arquivo: `sme_uniforme_apps/proponentes/tests/test_anexo/test_admin.py`

- Valida que a tela de edição do proponente exibe `Status IA`, `Justificativa IA`, `Status Admin` e `Justificativa Admin`, sem inputs editáveis para os campos da IA.
- Garante que o salvamento no admin copia a justificativa da IA para o campo administrativo e registra usuário/data da alteração.
- Garante que a informação de auditoria aparece na tela do admin.
- Garante que o texto de auditoria é montado com nome do usuário e data formatada.
- Valida que a justificativa da IA é renderizada em bloco readonly com o atributo `data-justificativa-ia`.
- Garante que a coluna `Justificativa IA` permanece vazia quando não existe conteúdo.
- Valida a renderização compacta do `Status IA` para valores conhecidos.
- Garante que um `Status IA` externo e desconhecido continua sendo exibido corretamente, sem dependência de `choices` fixos.

Arquivo: `sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py`

- Garante que o campo `tipo_documento` recebe `title` com o nome completo do documento quando a instância já possui valor.
- Garante a cópia automática da justificativa da IA para a justificativa administrativa quando o status é marcado como `Reprovado` ou `Vencido`.

### ✏️ Teste alterado

Arquivo: `sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py`

- Valida os labels do `AnexoForm`, o valor inicial do `Status Admin`, os estilos de `tipo_documento` e `justificativa` e a não exposição de `status_ia` e `justificativa_ia` como campos editáveis.

### 🖥️ Validação manual realizada

- Conferência visual do inline de anexos no navegador.
- Verificação de alinhamento entre upload do arquivo, data de validade, `Status IA` e `Status Admin`.
- Verificação de largura ampliada da `Justificativa Admin`.
- Verificação de `tipo_documento` com largura controlada e `title` contendo o nome completo.
- Verificação de `Justificativa IA` vazia sem texto placeholder.
- Verificação de que o CSS dos anexos não é carregado nas listagens `/admin/proponentes/proponente/` e `/admin/proponentes/ofertadeuniforme/`.

## 🔄 Migrações

- Migrations incluídas:
  `0033_anexo_campos_ia_e_auditoria`
  `0034_altera_status_ia_aberto`

## ⚠️ Pontos de Atenção

- A integração com a ferramenta externa de IA ainda não faz parte desta PR; a estrutura foi preparada para recebê-la.
- O fluxo público de criação de anexos continua sem aceitar diretamente campos de IA e auditoria.
- O `Status IA` agora aceita qualquer string externa, por isso, o tratamento visual no admin foi feito para valores conhecidos e desconhecidos.

## ✅ Resumo Final

- A PR prepara o backend para armazenar e exibir o resultado da análise de IA em anexos.
- O gestor passa a validar o resultado diretamente no Django Admin com rastreabilidade.
- O admin foi ajustado para usabilidade real, sem expor edição dos campos vindos da IA.
- O `Status IA` foi desacoplado de `choices` fixos e passou a aceitar valores externos livres.
