### PR TITLE
Feature(150311) Suporte para CNPJ Alfanumérico e Comprovante de Endereço Para Cada Loja

### DIFF
--- a/sme_uniforme_apps/proponentes/admin.py
+++ b/sme_uniforme_apps/proponentes/admin.py
@@ -27,7 +27,6 @@ class UniformesFornecidosInLine(admin.TabularInline):
 class LojasInLine(admin.StackedInline):
     form = LojaAdminForm
     model = Loja
-    exclude = ('comprovante_endereco',)
     extra = 1  # Quantidade de linhas que serão exibidas.
 
 
@@ -375,7 +374,6 @@ class ListaNegraAdmin(admin.ModelAdmin):
 @admin.register(Loja)
 class LojaAdmin(admin.ModelAdmin):
     form = LojaAdminForm
-    exclude = ('comprovante_endereco',)
 
     @staticmethod
     def protocolo(loja):

--- a/sme_uniforme_apps/proponentes/api/serializers/proponente_serializer.py
+++ b/sme_uniforme_apps/proponentes/api/serializers/proponente_serializer.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
 from ....core.models import LimiteCategoria, Uniforme
+from ...cnpj import CNPJ_VALIDATION_MESSAGE, first_access_password, format_cnpj
 from ...api.serializers.anexo_serializer import AnexoSerializer
 from ...api.serializers.loja_serializer import (LojaCreateSerializer,
                                                 LojaSerializer)
@@ -29,9 +30,32 @@ class ProponenteSerializer(serializers.ModelSerializer):
 
 
 class ProponenteCreateSerializer(serializers.ModelSerializer):
+    cnpj = serializers.CharField(
+        allow_blank=True,
+        allow_null=True,
+        required=False,
+        validators=[],
+    )
 
     ofertas_de_uniformes = OfertaDeUniformeCreateSerializer(many=True)
     lojas = LojaCreateSerializer(many=True)
+
+    def validate_cnpj(self, value):
+        if not value:
+            return value
+
+        normalized_cnpj = format_cnpj(value)
+        if not Proponente.cnpj_valido(normalized_cnpj):
+            raise serializers.ValidationError(CNPJ_VALIDATION_MESSAGE)
+
+        queryset = Proponente.objects.all()
+        if self.instance:
+            queryset = queryset.exclude(pk=self.instance.pk)
+
+        if queryset.filter(cnpj=normalized_cnpj).exists():
+            raise serializers.ValidationError("Já existe um proponente com este CNPJ.")
+
+        return normalized_cnpj
 
     @staticmethod
     def categoria_acima_limite(ofertas_de_uniformes):
@@ -127,7 +151,7 @@ class ProponenteCreateSerializer(serializers.ModelSerializer):
         log.info("Criação de usuário do proponente")
         usuario = User.objects.create_user(
             email=proponente.email,
-            password="".join([n for n in proponente.cnpj if n.isdigit()])[:5],
+            password=first_access_password(proponente.cnpj),
             first_name=proponente.responsavel.split(' ')[0],
             last_name=' '.join(proponente.responsavel.split(' ')[1:])
         )

--- a/sme_uniforme_apps/proponentes/api/viewsets/proponentes_viewset.py
+++ b/sme_uniforme_apps/proponentes/api/viewsets/proponentes_viewset.py
@@ -105,9 +105,12 @@ class ProponentesViewSet(mixins.CreateModelMixin,
                 loja_obj.telefone = loja.get('telefone')
                 loja_obj.site = loja.get('site')
                 comprovante_endereco = self._validate_comprovante_endereco(loja)
-                if comprovante_endereco:
-                    file = base64ToFile(comprovante_endereco)
-                    loja_obj.comprovante_endereco.save('comprovante_endereco_loja.' + file['ext'], file['data'])
+                if 'comprovante_endereco' in loja:
+                    if comprovante_endereco is not None:
+                        file = base64ToFile(comprovante_endereco)
+                        loja_obj.comprovante_endereco.save('comprovante_endereco_loja.' + file['ext'], file['data'])
+                    else:
+                        loja_obj.comprovante_endereco = None
                 loja_obj.save()
             else:
                 atributos_extras = ['proponente', 'uuid', 'id', 'email', 'criado_em',

--- a/sme_uniforme_apps/proponentes/api/viewsets/proponentes_viewset.py
+++ b/sme_uniforme_apps/proponentes/api/viewsets/proponentes_viewset.py
@@ -47,6 +47,22 @@ class ProponentesViewSet(mixins.CreateModelMixin,
         else:
             return ProponenteCreateSerializer
 
+    @staticmethod
+    def _validate_comprovante_endereco(loja):
+        comprovante_endereco = loja.get("comprovante_endereco")
+
+        if comprovante_endereco:
+            try:
+                validate_upload_extension(
+                    comprovante_endereco,
+                    PDF_EXTENSIONS,
+                    "Envie o comprovante de endereço do ponto de venda em PDF.",
+                )
+            except ValueError as exc:
+                raise ValidationError(str(exc))
+
+        return comprovante_endereco
+
     @action(detail=True, methods=['patch'], url_path='atualiza-lojas')
     def atualiza_lojas(self, request, uuid):
         proponente = self.get_object()
@@ -88,17 +104,8 @@ class ProponentesViewSet(mixins.CreateModelMixin,
                 loja_obj.nome_fantasia = loja.get('nome_fantasia')
                 loja_obj.telefone = loja.get('telefone')
                 loja_obj.site = loja.get('site')
-                comprovante_endereco = loja.get('comprovante_endereco')
+                comprovante_endereco = self._validate_comprovante_endereco(loja)
                 if comprovante_endereco:
-                    try:
-                        validate_upload_extension(
-                            comprovante_endereco,
-                            PDF_EXTENSIONS,
-                            'Envie o comprovante de endereço do ponto de venda em PDF.',
-                        )
-                    except ValueError as exc:
-                        raise ValidationError(str(exc))
-
                     file = base64ToFile(comprovante_endereco)
                     loja_obj.comprovante_endereco.save('comprovante_endereco_loja.' + file['ext'], file['data'])
                 loja_obj.save()
@@ -108,18 +115,10 @@ class ProponentesViewSet(mixins.CreateModelMixin,
                                     'uf', 'firstName']
                 for attr in atributos_extras:
                     loja.pop(attr, '')
-                comprovante = loja.pop('comprovante_endereco', None)
+                comprovante = self._validate_comprovante_endereco(loja)
+                loja.pop('comprovante_endereco', None)
                 loja_object = LojaCreateSerializer().create(loja)
                 if comprovante:
-                    try:
-                        validate_upload_extension(
-                            comprovante,
-                            PDF_EXTENSIONS,
-                            'Envie o comprovante de endereço do ponto de venda em PDF.',
-                        )
-                    except ValueError as exc:
-                        raise ValidationError(str(exc))
-
                     file = base64ToFile(comprovante)
                     loja_object.comprovante_endereco.save('comprovante_endereco_loja.' + file['ext'], file['data'])
                 proponente.lojas.add(loja_object)

--- a/sme_uniforme_apps/proponentes/cnpj.py
+++ b/sme_uniforme_apps/proponentes/cnpj.py
@@ -1,0 +1,68 @@
+import re
+
+CNPJ_VALIDATION_MESSAGE = "Digite CNPJ válido no formato XX.XXX.XXX/XXXX-XX, com letras e números quando aplicável."
+CNPJ_LENGTH = 14
+CNPJ_BODY_LENGTH = 12
+CNPJ_FORMATTED_RE = re.compile(
+    r"^[A-Z0-9]{2}\.[A-Z0-9]{3}\.[A-Z0-9]{3}/[A-Z0-9]{4}-\d{2}$"
+)
+CNPJ_COMPACT_RE = re.compile(r"^[A-Z0-9]{12}\d{2}$")
+CNPJ_FIRST_DV_WEIGHTS = (5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2)
+CNPJ_SECOND_DV_WEIGHTS = (6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2)
+
+
+def sanitize_cnpj(value):
+    return str(value or "").strip().upper()
+
+
+def compact_cnpj(value):
+    return "".join(char for char in sanitize_cnpj(value) if char.isalnum())
+
+
+def format_cnpj(value):
+    compact = compact_cnpj(value)
+    if not CNPJ_COMPACT_RE.fullmatch(compact):
+        return sanitize_cnpj(value)
+
+    return "{}.{}.{}/{}-{}".format(
+        compact[:2],
+        compact[2:5],
+        compact[5:8],
+        compact[8:12],
+        compact[12:],
+    )
+
+
+def first_access_password(value):
+    compact = compact_cnpj(value)
+    if not compact:
+        return ""
+    return compact[:5]
+
+
+def validate_cnpj(value):
+    compact = compact_cnpj(value)
+    if not CNPJ_COMPACT_RE.fullmatch(compact):
+        return False
+
+    if compact.isdigit() and len(set(compact)) == 1:
+        return False
+
+    expected_dvs = _calculate_dvs(compact[:CNPJ_BODY_LENGTH])
+    return compact[-2:] == expected_dvs
+
+
+def _calculate_dvs(body):
+    first_digit = _calculate_dv(body, CNPJ_FIRST_DV_WEIGHTS)
+    second_digit = _calculate_dv(body + first_digit, CNPJ_SECOND_DV_WEIGHTS)
+    return first_digit + second_digit
+
+
+def _calculate_dv(base, weights):
+    total = sum(_character_value(char) * weight for char, weight in zip(base, weights))
+    remainder = total % 11
+    return "0" if remainder < 2 else str(11 - remainder)
+
+
+def _character_value(char):
+    return ord(char) - 48

--- a/sme_uniforme_apps/proponentes/models/forms.py
+++ b/sme_uniforme_apps/proponentes/models/forms.py
@@ -81,10 +81,33 @@ class LojaAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(LojaAdminForm, self).__init__(*args, **kwargs)
 
+        self.fields["comprovante_endereco"].label = (
+            "Comprovante de endereço do ponto de venda"
+        )
+        self.fields["comprovante_endereco"].help_text = (
+            "Campo opcional. Se enviado, deve estar em PDF."
+        )
         self.fields["foto_fachada"].label = "Foto da fachada da loja"
         self.fields["foto_fachada"].help_text = (
             "Envie apenas arquivos JPG, JPEG ou PNG."
         )
+
+    def clean_comprovante_endereco(self):
+        comprovante_endereco = self.cleaned_data.get("comprovante_endereco")
+
+        if not comprovante_endereco or "comprovante_endereco" not in self.changed_data:
+            return comprovante_endereco
+
+        try:
+            validate_upload_extension(
+                comprovante_endereco,
+                PDF_EXTENSIONS,
+                "Envie o comprovante de endereço do ponto de venda em PDF.",
+            )
+        except ValueError as exc:
+            raise forms.ValidationError(str(exc))
+
+        return comprovante_endereco
 
     def clean_foto_fachada(self):
         foto_fachada = self.cleaned_data.get("foto_fachada")

--- a/sme_uniforme_apps/proponentes/models/lista_negra.py
+++ b/sme_uniforme_apps/proponentes/models/lista_negra.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from ..cnpj import format_cnpj
 from .validators import cnpj_validation
 
 from sme_uniforme_apps.core.models_abstracts import ModeloBase
@@ -17,7 +18,17 @@ class ListaNegra(ModeloBase):
 
     @classmethod
     def cnpj_bloqueado(cls, cnpj):
-        return cls.objects.filter(cnpj=cnpj).exists()
+        return cls.objects.filter(cnpj=format_cnpj(cnpj)).exists()
+
+    def clean(self):
+        super().clean()
+        if self.cnpj:
+            self.cnpj = format_cnpj(self.cnpj)
+
+    def save(self, *args, **kwargs):
+        if self.cnpj:
+            self.cnpj = format_cnpj(self.cnpj)
+        super().save(*args, **kwargs)
 
     class Meta:
         verbose_name = "CNPJ bloqueado"

--- a/sme_uniforme_apps/proponentes/models/proponente.py
+++ b/sme_uniforme_apps/proponentes/models/proponente.py
@@ -1,7 +1,6 @@
 import environ
 import logging
 
-from brazilnum.cnpj import validate_cnpj
 from django.core import validators
 from django.db import models
 from django.db.models.signals import post_save, pre_save
@@ -15,6 +14,7 @@ from sme_uniforme_apps.core.models_abstracts import ModeloBase, TemObservacao
 from ..services import cnpj_esta_bloqueado
 from ..tasks import (enviar_email_confirmacao_cadastro,
                      enviar_email_confirmacao_pre_cadastro, enviar_email_pendencia)
+from ..cnpj import format_cnpj, validate_cnpj
 from .tipo_documento import TipoDocumento
 from .validators import cep_validation, cnpj_validation, phone_validation
 from django.contrib.auth import get_user_model
@@ -178,7 +178,7 @@ class Proponente(ModeloBase, TemObservacao):
 
     @classmethod
     def cnpj_ja_cadastrado(cls, cnpj):
-        return cls.objects.filter(cnpj=cnpj).exists()
+        return cls.objects.filter(cnpj=format_cnpj(cnpj)).exists()
 
     @staticmethod
     def cnpj_valido(cnpj):
@@ -186,11 +186,16 @@ class Proponente(ModeloBase, TemObservacao):
 
     @classmethod
     def bloqueia_por_cnpj(cls, cnpj):
-        Proponente.objects.filter(cnpj=cnpj).update(status=Proponente.STATUS_BLOQUEADO)
+        Proponente.objects.filter(cnpj=format_cnpj(cnpj)).update(status=Proponente.STATUS_BLOQUEADO)
 
     @classmethod
     def desbloqueia_por_cnpj(cls, cnpj):
-        Proponente.objects.filter(cnpj=cnpj).update(status=Proponente.STATUS_INSCRITO)
+        Proponente.objects.filter(cnpj=format_cnpj(cnpj)).update(status=Proponente.STATUS_INSCRITO)
+
+    def clean(self):
+        super().clean()
+        if self.cnpj:
+            self.cnpj = format_cnpj(self.cnpj)
 
     @classmethod
     def documentos_obrigatorios_enviados(cls, proponente):
@@ -233,7 +238,10 @@ def proponente_post_save(instance, created, **kwargs):
 
 @receiver(pre_save, sender=Proponente)
 def proponente_pre_save(instance, **kwargs):
-    if instance.status == Proponente.STATUS_INSCRITO and instance.cnpj and cnpj_esta_bloqueado(instance.cnpj):
+    if instance.cnpj:
+        instance.cnpj = format_cnpj(instance.cnpj)
+
+    if (instance.status == Proponente.STATUS_INSCRITO and instance.cnpj and cnpj_esta_bloqueado(instance.cnpj)):
         instance.status = Proponente.STATUS_BLOQUEADO
 
     elif instance.status == Proponente.STATUS_BLOQUEADO and instance.cnpj and not cnpj_esta_bloqueado(instance.cnpj):

--- a/sme_uniforme_apps/proponentes/models/validators.py
+++ b/sme_uniforme_apps/proponentes/models/validators.py
@@ -1,5 +1,7 @@
 from django.core import validators
+from django.core.exceptions import ValidationError
 
+from ..cnpj import CNPJ_VALIDATION_MESSAGE, validate_cnpj
 
 phone_validation = validators.RegexValidator(
     regex=r"^\(\d{2}\) [\d\-]{9,10}$",
@@ -12,12 +14,33 @@ cep_validation = validators.RegexValidator(
 )
 
 
-cpf_cnpj_validation = validators.RegexValidator(
-    regex=r"(^\d{3}\.\d{3}\.\d{3}\-\d{2}$)|(^\d{2}\.\d{3}\.\d{3}\/\d{4}\-\d{2}$)",
+cpf_validation = validators.RegexValidator(
+    regex=r"^\d{3}\.\d{3}\.\d{3}\-\d{2}$",
     message="Digite o CPF ou CNPJ no formato XX.XXX.XXX/XXXX-XX ou XXX.XXX.XXX-XX.",
 )
 
-cnpj_validation = validators.RegexValidator(
-    regex=r"(^\d{2}\.\d{3}\.\d{3}\/\d{4}\-\d{2}$)",
-    message="Digite CNPJ no formato XX.XXX.XXX/XXXX-XX.",
-)
+
+def cpf_cnpj_validation(value):
+    if not value:
+        return
+
+    try:
+        cpf_validation(value)
+        return
+    except ValidationError:
+        pass
+
+    try:
+        cnpj_validation(value)
+    except ValidationError:
+        raise ValidationError(
+            "Digite o CPF ou CNPJ no formato XX.XXX.XXX/XXXX-XX ou XXX.XXX.XXX-XX."
+        )
+
+
+def cnpj_validation(value):
+    if not value:
+        return
+
+    if not validate_cnpj(value):
+        raise ValidationError(CNPJ_VALIDATION_MESSAGE)

--- a/sme_uniforme_apps/proponentes/services.py
+++ b/sme_uniforme_apps/proponentes/services.py
@@ -3,6 +3,7 @@ import logging
 import requests
 from django.conf import settings
 
+from .cnpj import first_access_password
 from ..custom_user.models import User
 from .models.lista_negra import ListaNegra
 
@@ -23,7 +24,7 @@ def cria_usuario_proponentes_existentes(queryset):
             novo_usuario = User.objects.create_user(email=proponente.email,
                                                     first_name=proponente.responsavel.split(" ")[0],
                                                     last_name=" ".join(proponente.responsavel.split(" ")[1:]),
-                                                    password="".join([n for n in proponente.cnpj if n.isdigit()])[:5])
+                                                    password=first_access_password(proponente.cnpj))
             proponente.usuario = novo_usuario
             proponente.save()
 

--- a/sme_uniforme_apps/proponentes/templates/email/email_confirmacao_cadastro.html
+++ b/sme_uniforme_apps/proponentes/templates/email/email_confirmacao_cadastro.html
@@ -1,25 +1,25 @@
-{% extends "base/page.html" %}
+{% extends "base/page.html" %} 
 {% block content %}
-    <div class="row">
-        <div class="col-12 p-2">
-            <p>Caro fornecedor,</p>
-            <p>
-                Recebemos sua inscrição sob número de protocolo {{ protocolo }}. <br/>
-                A área técnica da Secretaria Municipal de
-                Educação analisará o seu cadastro e enviará parecer neste mesmo
-                email. <br/>
-                Favor aguardar nosso contato.
-            </p>
-            <p>
-                Você pode consultar seu status e atualizar suas informações em:<br/>
+<div class="row">
+  <div class="col-12 p-2">
+    <p>Caro fornecedor,</p>
+    <p>
+      Recebemos sua inscrição sob número de protocolo {{ protocolo }}. <br/>
+      A área técnica da Secretaria Municipal de
+      Educação analisará o seu cadastro e enviará parecer neste mesmo 
+      email. <br/>
+      Favor aguardar nosso contato.
+    </p>
+    <p>
+      Você pode consultar seu status e atualizar suas informações em:<br/>
 
-                <a href="https://portaldeuniformes.sme.prefeitura.sp.gov.br/login">
-                    https://portaldeuniformes.sme.prefeitura.sp.gov.br/login
-                </a><br/><br/>
-                O seu login e senha de primeiro acesso são:<br/>
-                <strong>login:</strong> {{ email }}<br/>
-                <strong>senha:</strong> 5 primeiros números do CNPJ<br/><br/>
-            </p>
-        </div>
-    </div>
+      <a href="https://portaldeuniformes.sme.prefeitura.sp.gov.br/login">
+        https://portaldeuniformes.sme.prefeitura.sp.gov.br/login
+    </a><br/><br/>
+      O seu login e senha de primeiro acesso são:<br/>
+      <strong>login:</strong> {{ email }}<br/>
+      <strong>senha:</strong> 5 primeiros caracteres do CNPJ<br/><br/>
+    </p>
+  </div>
+</div>
 {% endblock %}

--- a/sme_uniforme_apps/proponentes/tests/test_lista_negra/test_lista_negra_model.py
+++ b/sme_uniforme_apps/proponentes/tests/test_lista_negra/test_lista_negra_model.py
@@ -1,7 +1,7 @@
 import pytest
+from model_bakery import baker
 
 from sme_uniforme_apps.proponentes.models import ListaNegra
-
 
 pytestmark = pytest.mark.django_db
 
@@ -20,3 +20,12 @@ def test_cnpj_bloqueado_resultado_negativo(lista_negra):
     cnpj_nao_bloqueado = '73.110.385/0001-13'
     assert not ListaNegra.cnpj_bloqueado(cnpj_nao_bloqueado)
 
+
+def test_cnpj_bloqueado_resultado_positivo_para_alfanumerico():
+    baker.make(
+        "ListaNegra",
+        cnpj="AB.12C.3D4/0001-39",
+        razao_social="Bloqueado Alfa",
+    )
+
+    assert ListaNegra.cnpj_bloqueado("ab12c3d4000139")

--- a/sme_uniforme_apps/proponentes/tests/test_loja/test_model.py
+++ b/sme_uniforme_apps/proponentes/tests/test_loja/test_model.py
@@ -1,19 +1,57 @@
 import pytest
+from pathlib import Path
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import RequestFactory
 
 from ...admin import LojasInLine, LojaAdmin
-from ...models import Loja
+from ...models import Loja, Proponente
 from ...models.forms import LojaAdminForm
 
 pytestmark = pytest.mark.django_db
 
+User = get_user_model()
+MISSING = object()
 
-def create_uploaded_file(file_name):
-    return SimpleUploadedFile(file_name, b"conteudo_teste")
+
+@pytest.fixture
+def admin_user():
+    return User.objects.create_superuser(
+        email="gestor-loja@teste.com", password="123456"
+    )
 
 
-def create_loja_admin_form(file_name):
+PDF_BYTES = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF"
+
+
+def create_uploaded_file(file_name, content=b"conteudo_teste", content_type=None):
+    return SimpleUploadedFile(file_name, content, content_type=content_type)
+
+
+def create_pdf_uploaded_file(file_name="comprovante.pdf"):
+    return create_uploaded_file(file_name, PDF_BYTES, "application/pdf")
+
+
+def create_image_uploaded_file(file_name="fachada.png"):
+    return create_uploaded_file(file_name, content_type="image/png")
+
+
+def create_loja_admin_form(foto_fachada=MISSING, comprovante_endereco=MISSING):
+    files = {}
+
+    if foto_fachada is MISSING:
+        foto_fachada = create_image_uploaded_file()
+    if comprovante_endereco is MISSING:
+        comprovante_endereco = create_pdf_uploaded_file()
+
+    if foto_fachada is not None:
+        files["foto_fachada"] = foto_fachada
+    if comprovante_endereco is not None:
+        files["comprovante_endereco"] = comprovante_endereco
+
     return LojaAdminForm(
         data={
             "nome_fantasia": "Loja Teste",
@@ -26,7 +64,7 @@ def create_loja_admin_form(file_name):
             "numero_iptu": "",
             "site": "",
         },
-        files={"foto_fachada": create_uploaded_file(file_name)},
+        files=files,
     )
 
 
@@ -34,15 +72,33 @@ def test_loja(proponente, loja_fisica):
     assert isinstance(loja_fisica, Loja)
 
 
-def test_admin_loja_esconde_comprovante_endereco():
+def test_admin_loja_exibe_comprovante_endereco(proponente, admin_user):
+    request = RequestFactory().get("/")
+    request.user = admin_user
+    loja_admin = LojaAdmin(Loja, AdminSite())
+    inline = LojasInLine(Proponente, AdminSite())
+
     assert LojasInLine.form == LojaAdminForm
-    assert LojasInLine.exclude == ("comprovante_endereco",)
-    assert LojaAdmin.exclude == ("comprovante_endereco",)
+    assert "comprovante_endereco" in loja_admin.get_form(request).base_fields
+    assert (
+        "comprovante_endereco"
+        in inline.get_formset(request, proponente).form.base_fields
+    )
 
 
 def test_loja_admin_form_configura_label_e_help_text():
     form = LojaAdminForm()
 
+    assert not form.fields["comprovante_endereco"].required
+    assert (
+        form.fields["comprovante_endereco"].label
+        == "Comprovante de endereço do ponto de venda"
+    )
+    assert (
+        form.fields["comprovante_endereco"].help_text
+        == "Campo opcional. Se enviado, deve estar em PDF."
+    )
+    assert not form.fields["foto_fachada"].required
     assert form.fields["foto_fachada"].label == "Foto da fachada da loja"
     assert (
         form.fields["foto_fachada"].help_text
@@ -52,19 +108,60 @@ def test_loja_admin_form_configura_label_e_help_text():
 
 @pytest.mark.parametrize("file_name", ["fachada.png", "fachada.jpg", "fachada.jpeg"])
 def test_loja_admin_form_aceita_uploads_de_imagem(file_name):
-    form = create_loja_admin_form(file_name)
+    form = create_loja_admin_form(foto_fachada=create_uploaded_file(file_name))
 
     assert form.is_valid(), form.errors
 
 
 @pytest.mark.parametrize("file_name", ["fachada.pdf", "fachada.txt"])
 def test_loja_admin_form_rejeita_uploads_invalidos(file_name):
-    form = create_loja_admin_form(file_name)
+    form = create_loja_admin_form(foto_fachada=create_uploaded_file(file_name))
 
     assert not form.is_valid()
     assert form.errors["foto_fachada"] == [
         "Envie a foto da fachada em JPG, JPEG ou PNG."
     ]
+
+
+def test_loja_admin_form_aceita_comprovante_endereco_pdf():
+    form = create_loja_admin_form(
+        comprovante_endereco=create_pdf_uploaded_file(),
+    )
+
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.parametrize("file_name", ["comprovante.jpg", "comprovante.txt"])
+def test_loja_admin_form_rejeita_comprovante_endereco_invalido(file_name):
+    form = create_loja_admin_form(
+        comprovante_endereco=create_uploaded_file(file_name),
+    )
+
+    assert not form.is_valid()
+    assert form.errors["comprovante_endereco"] == [
+        "Envie o comprovante de endereço do ponto de venda em PDF."
+    ]
+
+
+def test_loja_persiste_comprovante_endereco_no_disco(settings, tmp_path, proponente):
+    settings.MEDIA_ROOT = str(tmp_path)
+    loja = Loja.objects.create(
+        proponente=proponente,
+        nome_fantasia="Loja Teste",
+        cep="27600-000",
+        endereco="Rua Teste",
+        bairro="Centro",
+        numero="123",
+        complemento="loja 1",
+        telefone="(11) 4565-9876",
+        comprovante_endereco=create_pdf_uploaded_file(),
+    )
+
+    assert loja.comprovante_endereco
+    assert loja.comprovante_endereco.name.endswith(".pdf")
+    assert Path(loja.comprovante_endereco.path).exists()
+
+    loja.comprovante_endereco.delete(save=False)
 
 
 def test_validacao_telefone_fora_formato(proponente):

--- a/sme_uniforme_apps/proponentes/tests/test_loja/test_serializers.py
+++ b/sme_uniforme_apps/proponentes/tests/test_loja/test_serializers.py
@@ -1,8 +1,46 @@
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from ...api.serializers.loja_serializer import (LojaCreateSerializer, LojaSerializer, LojaUpdateFachadaSerializer)
 
 pytestmark = pytest.mark.django_db
+
+PDF_BYTES = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF"
+
+
+def create_uploaded_file(file_name, content=b"conteudo_teste", content_type=None):
+    return SimpleUploadedFile(file_name, content, content_type=content_type)
+
+
+def create_loja_payload(foto_fachada=None, comprovante_endereco=None):
+    payload = {
+        "nome_fantasia": "Loja Teste",
+        "cep": "27600-000",
+        "endereco": "Rua Teste",
+        "bairro": "Centro",
+        "numero": "123",
+        "complemento": "loja 1",
+        "telefone": "(11) 4565-9876",
+        "numero_iptu": "",
+        "foto_fachada": create_uploaded_file("fachada.png", content_type="image/png"),
+        "comprovante_endereco": create_uploaded_file(
+            "comprovante.pdf",
+            content=PDF_BYTES,
+            content_type="application/pdf",
+        ),
+    }
+
+    if foto_fachada is None:
+        payload.pop("foto_fachada")
+    elif foto_fachada is not False:
+        payload["foto_fachada"] = foto_fachada
+
+    if comprovante_endereco is None:
+        payload.pop("comprovante_endereco")
+    elif comprovante_endereco is not False:
+        payload["comprovante_endereco"] = comprovante_endereco
+
+    return payload
 
 
 def test_loja_serializer(loja_fisica):
@@ -42,9 +80,24 @@ def test_loja_create_serializer_configura_campos_de_upload():
     assert foto_fachada.help_text == "Envie apenas arquivos JPG, JPEG ou PNG."
 
 
+def test_loja_create_serializer_rejeita_comprovante_endereco_nao_pdf():
+    payload_loja = create_loja_payload(
+        comprovante_endereco=create_uploaded_file("comprovante.txt")
+    )
+
+    serializer = LojaCreateSerializer(data=payload_loja)
+
+    assert not serializer.is_valid()
+    assert serializer.errors["comprovante_endereco"] == [
+        "Envie o comprovante de endereço do ponto de venda em PDF."
+    ]
+
+
 def test_loja_update_fachada_serializer_configura_label_e_help_text():
     serializer = LojaUpdateFachadaSerializer()
 
+    assert not serializer.fields["foto_fachada"].required
+    assert serializer.fields["foto_fachada"].allow_null
     assert serializer.fields["foto_fachada"].label == "Foto da fachada da loja"
     assert (
         serializer.fields["foto_fachada"].help_text
@@ -52,14 +105,20 @@ def test_loja_update_fachada_serializer_configura_label_e_help_text():
     )
 
 
-def test_loja_fachada_update(payload_update_fachada_loja):
-    loja_partial_update = LojaUpdateFachadaSerializer(data=payload_update_fachada_loja)
+def test_loja_fachada_update():
+    loja_partial_update = LojaUpdateFachadaSerializer(
+        data={
+            "foto_fachada": create_uploaded_file(
+                "fachada.png", content_type="image/png"
+            )
+        }
+    )
     assert loja_partial_update.is_valid()
 
 
-def test_loja_fachada_update_rejeita_extensao_invalida(arquivo_txt_base64):
+def test_loja_fachada_update_rejeita_extensao_invalida():
     loja_partial_update = LojaUpdateFachadaSerializer(
-        data={"foto_fachada": arquivo_txt_base64}
+        data={"foto_fachada": create_uploaded_file("fachada.txt")}
     )
 
     assert not loja_partial_update.is_valid()

--- a/sme_uniforme_apps/proponentes/tests/test_proponente/test_api_post_novo_proponente.py
+++ b/sme_uniforme_apps/proponentes/tests/test_proponente/test_api_post_novo_proponente.py
@@ -1,11 +1,26 @@
 import json
 
 import pytest
+from model_bakery import baker
 from rest_framework import status
 
+from sme_uniforme_apps.core.models import Uniforme
 from sme_uniforme_apps.proponentes.models import Proponente
 
 pytestmark = pytest.mark.django_db
+
+
+def configure_limites_permissivos():
+    baker.make(
+        "LimiteCategoria",
+        categoria_uniforme=Uniforme.CATEGORIA_KIT_VERAO,
+        preco_maximo=999,
+    )
+    baker.make(
+        "LimiteCategoria",
+        categoria_uniforme=Uniforme.CATEGORIA_KIT_INVERNO,
+        preco_maximo=999,
+    )
 
 
 def test_proponente_api_create_valida_limite_categoria(
@@ -25,6 +40,7 @@ def test_proponente_api_create_valida_fornecimento_total_categoria(
         client, payload_proponente,
         payload_ofertas_de_uniformes_faltando_a_camisa,
         uniforme_camisa, uniforme_calca, uniforme_tenis, uniforme_meias):
+    configure_limites_permissivos()
     payload_proponente["ofertas_de_uniformes"] = payload_ofertas_de_uniformes_faltando_a_camisa
     response = client.post('/proponentes/', data=json.dumps(payload_proponente), content_type='application/json')
     result = json.loads(response.content)
@@ -35,6 +51,7 @@ def test_proponente_api_create_valida_fornecimento_total_categoria(
 
 
 def test_proponente_api_create_sem_anexos(client, payload_proponente_sem_anexos):
+    configure_limites_permissivos()
     response = client.post('/proponentes/', data=json.dumps(payload_proponente_sem_anexos),
                            content_type='application/json')
 
@@ -42,3 +59,51 @@ def test_proponente_api_create_sem_anexos(client, payload_proponente_sem_anexos)
 
     result = json.loads(response.content)
     assert Proponente.objects.filter(uuid=result["uuid"]).exists()
+
+
+def test_proponente_api_create_com_cnpj_alfanumerico(
+    client,
+    payload_proponente_sem_anexos,
+):
+    configure_limites_permissivos()
+    payload_proponente_sem_anexos["cnpj"] = "AB.12C.3D4/0001-39"
+
+    response = client.post(
+        "/proponentes/",
+        data=json.dumps(payload_proponente_sem_anexos),
+        content_type="application/json",
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    result = json.loads(response.content)
+    assert Proponente.objects.filter(uuid=result["uuid"]).exists()
+
+
+def test_proponente_api_create_rejeita_cnpj_alfanumerico_duplicado_com_formato_diferente(
+    client,
+    payload_proponente_sem_anexos,
+):
+    configure_limites_permissivos()
+    Proponente.objects.create(
+        cnpj="AB.12C.3D4/0001-39",
+        razao_social="Empresa Existente",
+        end_logradouro="Rua Teste",
+        end_cidade="São Paulo",
+        end_uf="SP",
+        end_cep="99999-000",
+        telefone="(11) 99999-9999",
+        email="existente@teste.com",
+        responsavel="Responsavel Existente",
+    )
+    payload_proponente_sem_anexos["cnpj"] = "ab12c3d4000139"
+
+    response = client.post(
+        "/proponentes/",
+        data=json.dumps(payload_proponente_sem_anexos),
+        content_type="application/json",
+    )
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result["cnpj"] == ["Já existe um proponente com este CNPJ."]

--- a/sme_uniforme_apps/proponentes/tests/test_proponente/test_api_proponentess_verifica_cnpj.py
+++ b/sme_uniforme_apps/proponentes/tests/test_proponente/test_api_proponentess_verifica_cnpj.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 from rest_framework import status
+from model_bakery import baker
 
 pytestmark = pytest.mark.django_db
 
@@ -70,4 +71,33 @@ def test_proponente_api_valida_cnpj_bloqueado(client, cnpj_bloqueado, lista_negr
                 'cnpj_valido': 'Sim',
                 'cnpj_cadastrado': 'Não',
                 'cnpj_bloqueado': 'Sim'
+            }
+
+
+def test_proponente_api_valida_cnpj_alfanumerico(client):
+    baker.make(
+        "Proponente",
+        cnpj="AB.12C.3D4/0001-39",
+        razao_social="Empresa Alfa",
+        end_logradouro="Rua Alfa",
+        end_cidade="São Paulo",
+        end_uf="SP",
+        end_cep="99999-000",
+        telefone="(11) 99999-9999",
+        email="empresa.alfa@teste.com",
+        responsavel="Responsavel Alfa",
+    )
+
+    response = client.get(
+        "/proponentes/verifica-cnpj/?cnpj=ab12c3d4000139",
+        content_type="application/json",
+    )
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == {
+        "result": "OK",
+        "cnpj_valido": "Sim",
+        "cnpj_cadastrado": "Sim",
+        "cnpj_bloqueado": "Não",
             }

--- a/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponente_model.py
+++ b/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponente_model.py
@@ -1,6 +1,7 @@
 import pytest
 from django.contrib import admin
 from django.contrib.auth import get_user_model
+from model_bakery import baker
 
 from sme_uniforme_apps.proponentes.admin import ProponenteAdmin
 from sme_uniforme_apps.proponentes.models import Proponente
@@ -43,7 +44,7 @@ def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[Proponente]
     assert model_admin.list_display == (
-        'protocolo', 'cnpj', 'razao_social', 'responsavel', 'telefone', 'email', 'ultima_alteracao', 'status')
+        'protocolo', 'cnpj', 'razao_social', 'responsavel', 'telefone', 'email', 'usuario', 'data_cadastro', 'ultima_alteracao', 'status')
     assert model_admin.ordering == ('-alterado_em',)
     assert model_admin.search_fields == ('uuid', 'cnpj', 'razao_social', 'responsavel')
 
@@ -67,9 +68,78 @@ def test_cnpj_valido_resultado_positivo():
     assert Proponente.cnpj_valido(cnpj_valido)
 
 
+def test_cnpj_alfanumerico_valido_resultado_positivo():
+    cnpj_valido = "AB.12C.3D4/0001-39"
+    assert Proponente.cnpj_valido(cnpj_valido)
+
+
 def test_cnpj_valido_resultado_negativo():
     cnpj_invalido = '73.110.385/0001-00'
     assert not Proponente.cnpj_valido(cnpj_invalido)
+
+
+def test_cnpj_alfanumerico_valido_resultado_negativo():
+    cnpj_invalido = "AB.12C.3D4/0001-30"
+    assert not Proponente.cnpj_valido(cnpj_invalido)
+
+
+def test_cnpj_ja_cadastrado_normaliza_formato_alfanumerico():
+    baker.make(
+        "Proponente",
+        cnpj="AB.12C.3D4/0001-39",
+        razao_social="Alfanumerico",
+        end_logradouro="Rua Teste",
+        end_cidade="São Paulo",
+        end_uf="SP",
+        end_cep="99999-000",
+        telefone="(99) 99999-9999",
+        email="alfanumerico@teste.com",
+        responsavel="Fulano Alfa",
+    )
+
+    assert Proponente.cnpj_ja_cadastrado("ab12c3d4000139")
+
+
+def test_bloqueia_por_cnpj_normaliza_formato_alfanumerico():
+    proponente = baker.make(
+        "Proponente",
+        cnpj="AB.12C.3D4/0001-39",
+        status=Proponente.STATUS_INSCRITO,
+        razao_social="Teste Alfa",
+        end_logradouro="Rua Teste",
+        end_cidade="São Paulo",
+        end_uf="SP",
+        end_cep="99999-000",
+        telefone="(99) 99999-9999",
+        email="bloqueia.alfa@teste.com",
+        responsavel="Fulano Alfa",
+    )
+
+    Proponente.bloqueia_por_cnpj("ab12c3d4000139")
+    proponente.refresh_from_db()
+
+    assert proponente.status == Proponente.STATUS_BLOQUEADO
+
+
+def test_desbloqueia_por_cnpj_normaliza_formato_alfanumerico():
+    proponente = baker.make(
+        "Proponente",
+        cnpj="AB.12C.3D4/0001-39",
+        status=Proponente.STATUS_BLOQUEADO,
+        razao_social="Teste Alfa",
+        end_logradouro="Rua Teste",
+        end_cidade="São Paulo",
+        end_uf="SP",
+        end_cep="99999-000",
+        telefone="(99) 99999-9999",
+        email="desbloqueia.alfa@teste.com",
+        responsavel="Fulano Alfa",
+    )
+
+    Proponente.desbloqueia_por_cnpj("ab12c3d4000139")
+    proponente.refresh_from_db()
+
+    assert proponente.status == Proponente.STATUS_INSCRITO
 
 
 def test_proponente_status_default_em_processo(proponente):

--- a/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponente_serializer.py
+++ b/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponente_serializer.py
@@ -1,6 +1,16 @@
 import pytest
+from pathlib import Path
 
-from sme_uniforme_apps.proponentes.api.serializers.proponente_serializer import ProponenteSerializer, ProponenteLookUpSerializer
+from django.core.files.uploadedfile import SimpleUploadedFile
+from model_bakery import baker
+
+from sme_uniforme_apps.core.models import Uniforme
+
+from sme_uniforme_apps.proponentes.api.serializers.proponente_serializer import (
+    ProponenteCreateSerializer,
+    ProponenteLookUpSerializer,
+    ProponenteSerializer,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -36,3 +46,52 @@ def test_proponente_lookup_serializer(proponente):
     assert proponente_serializer.data['razao_social']
     assert proponente_serializer.data['uuid']
 
+
+def test_proponente_create_serializer_cria_loja_com_comprovante_endereco(
+    payload_proponente_sem_anexos,
+    settings,
+    tmp_path,
+):
+    settings.MEDIA_ROOT = str(tmp_path)
+    baker.make(
+        "LimiteCategoria",
+        categoria_uniforme=Uniforme.CATEGORIA_KIT_VERAO,
+        preco_maximo=999,
+    )
+    baker.make(
+        "LimiteCategoria",
+        categoria_uniforme=Uniforme.CATEGORIA_KIT_INVERNO,
+        preco_maximo=999,
+    )
+    payload_proponente_sem_anexos["lojas"][0]["foto_fachada"] = SimpleUploadedFile(
+        "fachada.png",
+        b"conteudo_teste",
+        content_type="image/png",
+    )
+    payload_proponente_sem_anexos["lojas"][0]["comprovante_endereco"] = (
+        SimpleUploadedFile(
+            "comprovante.pdf",
+            b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF",
+            content_type="application/pdf",
+        )
+    )
+
+    serializer = ProponenteCreateSerializer(data=payload_proponente_sem_anexos)
+
+    assert serializer.is_valid(), serializer.errors
+
+    proponente = serializer.save()
+    loja = proponente.lojas.get(nome_fantasia="Loja A")
+    proponente_serializer = ProponenteSerializer(proponente)
+    comprovante_url = next(
+        loja_payload["comprovante_endereco"]
+        for loja_payload in proponente_serializer.data["lojas"]
+        if loja_payload["nome_fantasia"] == "Loja A"
+    )
+
+    assert loja.comprovante_endereco
+    assert Path(loja.comprovante_endereco.path).exists()
+    assert comprovante_url
+    assert comprovante_url.endswith(".pdf")
+
+    loja.comprovante_endereco.delete(save=False)

--- a/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py
+++ b/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py
@@ -10,9 +10,11 @@ pytestmark = pytest.mark.django_db
 
 ARQUIVO_JPG_BASE64 = "data:image/jpg;base64,/9j/4AAQSkZJRgABAQ=="
 
+MISSING = object()
+
 
 def create_payload_atualiza_lojas(
-    uniforme_nome, comprovante_endereco=None, loja_id=None
+    uniforme_nome, comprovante_endereco=MISSING, loja_id=None
 ):
     loja = {
         "nome_fantasia": "Loja Atualizada",
@@ -26,7 +28,7 @@ def create_payload_atualiza_lojas(
     }
     if loja_id:
         loja["id"] = loja_id
-    if comprovante_endereco is not None:
+    if comprovante_endereco is not MISSING:
         loja["comprovante_endereco"] = comprovante_endereco
 
     return {
@@ -152,6 +154,54 @@ def test_url_atualiza_lojas_com_comprovante_endereco_pdf(
     mock_atualiza_coordenadas_lojas.assert_called_once()
 
     loja_fisica.comprovante_endereco.delete(save=False)
+
+
+@patch(
+    "sme_uniforme_apps.proponentes.api.viewsets.proponentes_viewset.atualiza_coordenadas_lojas"
+)
+def test_url_atualiza_lojas_remove_comprovante_endereco(
+    mock_atualiza_coordenadas_lojas,
+    client,
+    proponente,
+    loja_fisica,
+    uniforme_calca,
+    arquivo_anexo_base64,
+    settings,
+    tmp_path,
+):
+    settings.MEDIA_ROOT = str(tmp_path)
+    # Primeiro adiciona comprovante
+    payload_adiciona = create_payload_atualiza_lojas(
+        uniforme_calca.nome,
+        comprovante_endereco=arquivo_anexo_base64,
+        loja_id=loja_fisica.id,
+    )
+    client.patch(
+        f"/proponentes/{proponente.uuid}/atualiza-lojas/",
+        data=json.dumps(payload_adiciona),
+        content_type="application/json",
+    )
+    loja_fisica.refresh_from_db()
+    assert loja_fisica.comprovante_endereco
+
+    # Agora remove comprovante enviando None
+    payload_remove = create_payload_atualiza_lojas(
+        uniforme_calca.nome,
+        comprovante_endereco=None,
+        loja_id=loja_fisica.id,
+    )
+    response = client.patch(
+        f"/proponentes/{proponente.uuid}/atualiza-lojas/",
+        data=json.dumps(payload_remove),
+        content_type="application/json",
+    )
+    result = json.loads(response.content)
+    loja_fisica.refresh_from_db()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert not loja_fisica.comprovante_endereco
+    assert result["lojas"][0]["comprovante_endereco"] is None
+    mock_atualiza_coordenadas_lojas.assert_called()
 
 
 @patch(

--- a/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py
+++ b/sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -82,6 +83,42 @@ def test_url_atualiza_lojas_sem_comprovante_endereco(
 @patch(
     "sme_uniforme_apps.proponentes.api.viewsets.proponentes_viewset.atualiza_coordenadas_lojas"
 )
+def test_url_atualiza_lojas_adiciona_comprovante_endereco_pdf(
+    mock_atualiza_coordenadas_lojas,
+    client,
+    proponente,
+    uniforme_calca,
+    arquivo_anexo_base64,
+    settings,
+    tmp_path,
+):
+    settings.MEDIA_ROOT = str(tmp_path)
+    payload = create_payload_atualiza_lojas(
+        uniforme_calca.nome,
+        comprovante_endereco=arquivo_anexo_base64,
+    )
+
+    response = client.patch(
+        f"/proponentes/{proponente.uuid}/atualiza-lojas/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    result = json.loads(response.content)
+    proponente.refresh_from_db()
+    loja_fisica = proponente.lojas.first()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert loja_fisica.comprovante_endereco
+    assert Path(loja_fisica.comprovante_endereco.path).exists()
+    assert result["lojas"][0]["comprovante_endereco"].endswith(".pdf")
+    mock_atualiza_coordenadas_lojas.assert_called_once()
+
+    loja_fisica.comprovante_endereco.delete(save=False)
+
+
+@patch(
+    "sme_uniforme_apps.proponentes.api.viewsets.proponentes_viewset.atualiza_coordenadas_lojas"
+)
 def test_url_atualiza_lojas_com_comprovante_endereco_pdf(
     mock_atualiza_coordenadas_lojas,
     client,
@@ -89,7 +126,10 @@ def test_url_atualiza_lojas_com_comprovante_endereco_pdf(
     loja_fisica,
     uniforme_calca,
     arquivo_anexo_base64,
+    settings,
+    tmp_path,
 ):
+    settings.MEDIA_ROOT = str(tmp_path)
     payload = create_payload_atualiza_lojas(
         uniforme_calca.nome,
         comprovante_endereco=arquivo_anexo_base64,
@@ -101,12 +141,17 @@ def test_url_atualiza_lojas_com_comprovante_endereco_pdf(
         data=json.dumps(payload),
         content_type="application/json",
     )
+    result = json.loads(response.content)
 
     loja_fisica.refresh_from_db()
 
     assert response.status_code == status.HTTP_200_OK
     assert loja_fisica.comprovante_endereco
+    assert Path(loja_fisica.comprovante_endereco.path).exists()
+    assert result["lojas"][0]["comprovante_endereco"].endswith(".pdf")
     mock_atualiza_coordenadas_lojas.assert_called_once()
+
+    loja_fisica.comprovante_endereco.delete(save=False)
 
 
 @patch(

--- a/sme_uniforme_apps/triade/builders.py
+++ b/sme_uniforme_apps/triade/builders.py
@@ -2,6 +2,8 @@ import base64
 import json
 import os
 
+from sme_uniforme_apps.proponentes.cnpj import compact_cnpj
+
 from .exceptions import TriadePermanentError
 
 
@@ -274,7 +276,7 @@ class TriadePayloadBuilder:
 
     def _normalized_document_number(self, cnpj):
         cnpj = self._required_value(cnpj, "proponente.cnpj")
-        normalized = "".join(char for char in cnpj if char.isdigit())
+        normalized = compact_cnpj(cnpj)
         if not normalized:
             raise TriadePayloadBuilderError(
                 "TRIADE payload exige proponente.cnpj valido para envio."

--- a/sme_uniforme_apps/triade/tests/conftest.py
+++ b/sme_uniforme_apps/triade/tests/conftest.py
@@ -9,7 +9,7 @@ from sme_uniforme_apps.proponentes.models import Proponente
 def proponente_triade():
     return baker.make(
         "Proponente",
-        cnpj="00.529.476/0001-14",
+        cnpj="AB.12C.3D4/0001-39",
         razao_social="Empresa Teste LTDA",
         end_logradouro="Rua Teste, 123",
         end_cidade="Sao Paulo",

--- a/sme_uniforme_apps/triade/tests/test_payload_builder.py
+++ b/sme_uniforme_apps/triade/tests/test_payload_builder.py
@@ -23,7 +23,7 @@ def test_build_payload_monta_payload_com_primeira_loja_e_documento(
     assert payload["source_system"] == "portal_uniforme"
     assert payload["schema_version"] == "1.0"
     assert payload["external_batch_id"] == "PROTOCOLO-TRIADE-001"
-    assert payload["applicant"]["document_number"] == "00529476000114"
+    assert payload["applicant"]["document_number"] == "AB12C3D4000139"
     assert payload["applicant"]["name"] == "Empresa Teste LTDA"
     assert payload["applicant"]["fields"]["nome_fantasia"] == "Loja Centro"
     assert payload["applicant"]["fields"]["bairro"] == "Centro"


### PR DESCRIPTION
## 🌿 Contexto
Backend:
- Exposição e validação de `comprovante_endereco` por loja no backend e no Django Admin.
- Cobertura automatizada para upload/validação/persistência do comprovante por loja.
- Suporte a CNPJ alfanumérico conforme a nova regra da Receita Federal, com compatibilidade para CNPJ numérico legado.
- Ajuste do payload enviado para a TRIADE para preservar o CNPJ compactado alfanumérico.

## 🎯 Resumo

- **Loja:** o campo `comprovante_endereco`, que já existia no model `Loja`, passou a ficar visível no Django Admin, ganhou validação explícita de PDF no form/admin e cobertura de testes para visibilidade, validação e persistência. No frontend, foi adicionado input de upload por loja nos fluxos de cadastro e atualização, com exibição do comprovante já salvo e possibilidade de substituição.
- **CNPJ:** o backend e o frontend passaram a aceitar CNPJ alfanumérico, normalizando entrada, validando dígitos verificadores, tratando unicidade com máscara/case diferentes, refletindo isso no endpoint `verifica-cnpj`, na criação de usuários, no payload da TRIADE e em todos os campos de formulário do frontend.

## ✅ Entregas

### 🏬 Comprovante de Endereço por Loja

#### Backend
- Remoção do `exclude` de `comprovante_endereco` em `LojasInLine` e `LojaAdmin`, deixando o campo visível no Django Admin.
- Configuração de label e help text do campo no `LojaAdminForm`.
- Reaproveitamento da validação existente para aceitar apenas PDF no `comprovante_endereco`.
- Manutenção de `foto_fachada` como campo opcional com validação de imagem JPG/JPEG/PNG.
- Validação e persistência do comprovante no fluxo `PATCH /proponentes/{uuid}/atualiza-lojas/` quando o arquivo é enviado.
- Exposição da URL absoluta de `comprovante_endereco` no `LojaSerializer` quando o arquivo existe.

### 🧾 Suporte a CNPJ Alfanumérico

#### Backend
- Introdução de utilitário dedicado em `sme_uniforme_apps/proponentes/cnpj.py` para:
  - Sanitização.
  - Compactação.
  - Formatação.
  - Cálculo de DV em módulo 11 para CNPJ alfanumérico.
  - Geração da senha inicial a partir dos 5 primeiros caracteres compactados do CNPJ.
- Atualização dos validadores para aceitar CNPJ alfanumérico sem quebrar o suporte ao formato numérico legado.
- Normalização do CNPJ antes de operações críticas de comparação e persistência.
- Tratamento de duplicidade de CNPJ no serializer de criação, independente de máscara ou caixa.
- Ajuste dos helpers de bloqueio/desbloqueio e blacklist para comparação normalizada.

### 🔗 Integrações e Mensageria
- Ajuste da cópia do email de confirmação de cadastro: a senha de primeiro acesso passou a ser descrita como os 5 primeiros caracteres do CNPJ.
- Ajuste do `TriadePayloadBuilder` para enviar `applicant.document_number` com o CNPJ compactado alfanumérico, em vez de remover tudo que não fosse dígito.

## 🔄 Impacto Técnico e de Contrato
- Não há migração de banco nesta branch.
- `comprovante_endereco` continua opcional no backend e no frontend, mas quando enviado precisa ser PDF.
- `foto_fachada` continua opcional e, quando enviada, precisa ser JPG/JPEG/PNG.
- O endpoint `PATCH /proponentes/{uuid}/atualiza-lojas/` passou a validar e persistir `lojas[].comprovante_endereco` quando o campo for enviado.
- O serializer de loja expõe `comprovante_endereco` como URL quando o arquivo existe.
- O endpoint `GET /proponentes/verifica-cnpj/` agora aceita CNPJ numérico e alfanumérico, com ou sem máscara, e de forma case-insensitive.
- A criação de usuário passou a usar os 5 primeiros caracteres do CNPJ compactado como senha inicial, em vez de assumir apenas números.
- O payload da TRIADE passou a preservar o CNPJ compactado alfanumérico em `applicant.document_number`.
- O frontend passou a exibir o comprovante de endereço salvo (URL) e permitir substituí-lo por um novo PDF.
- A máscara de CNPJ no frontend agora aceita e formata letras maiúsculas, limitando a 18 caracteres com máscara aplicada.

## 🧪 Testes Criados e Alterados

### Backend
- `sme_uniforme_apps/proponentes/tests/test_loja/test_model.py`: cobre a exibição do campo `comprovante_endereco` no Django Admin, labels/help texts do form, aceite de PDF para comprovante, rejeição de extensões inválidas e persistência do arquivo no disco.
- `sme_uniforme_apps/proponentes/tests/test_loja/test_serializers.py`: cobre a configuração dos campos de upload do serializer de loja, rejeição de `comprovante_endereco` não PDF e a validação do serializer de atualização de fachada.
- `sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py`: cobre `atualiza-lojas` sem comprovante, com inclusão de comprovante PDF, com atualização de comprovante PDF e rejeição de comprovante inválido.
- `sme_uniforme_apps/proponentes/tests/test_proponente/test_proponente_serializer.py`: cobre a criação de proponente via serializer com loja contendo `comprovante_endereco`, validando persistência física do arquivo e URL retornada na serialização.
- `sme_uniforme_apps/proponentes/tests/test_proponente/test_api_post_novo_proponente.py`: cobre criação com CNPJ alfanumérico e rejeição de duplicidade quando o mesmo CNPJ é enviado com formatação diferente.
- `sme_uniforme_apps/proponentes/tests/test_proponente/test_api_proponentess_verifica_cnpj.py`: cobre o endpoint `verifica-cnpj` com CNPJ alfanumérico.
- `sme_uniforme_apps/proponentes/tests/test_proponente/test_proponente_model.py`: cobre CNPJ alfanumérico válido/inválido, normalização em `cnpj_ja_cadastrado` e normalização dos helpers `bloqueia_por_cnpj` e `desbloqueia_por_cnpj`.
- `sme_uniforme_apps/proponentes/tests/test_lista_negra/test_lista_negra_model.py`: cobre consulta de blacklist com CNPJ alfanumérico em formato compacto.
- `sme_uniforme_apps/triade/tests/test_payload_builder.py`: cobre o envio do `document_number` alfanumérico compactado no payload da TRIADE.

## ▶️ Validação Executada

### Backend

Comando:

```bash
docker compose -f docker-compose-dev.yml exec -T web pytest -q --disable-warnings \
    sme_uniforme_apps/proponentes/tests/test_loja/test_model.py \
    sme_uniforme_apps/proponentes/tests/test_loja/test_serializers.py \
    sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py \
    sme_uniforme_apps/proponentes/tests/test_proponente/test_proponente_serializer.py \
    sme_uniforme_apps/proponentes/tests/test_proponente/test_api_post_novo_proponente.py \
    sme_uniforme_apps/proponentes/tests/test_proponente/test_api_proponentess_verifica_cnpj.py \
    sme_uniforme_apps/proponentes/tests/test_proponente/test_proponente_model.py \
    sme_uniforme_apps/proponentes/tests/test_lista_negra/test_lista_negra_model.py \
    sme_uniforme_apps/triade/tests/test_payload_builder.py
```

Suíte focada do escopo alterado: `73 passed`.
