### PR TITLE
Feature(148713): Robustez e Ações Admin no TRIADE

### DIFF
--- a/sme_uniforme_apps/proponentes/admin.py
+++ b/sme_uniforme_apps/proponentes/admin.py
@@ -377,6 +377,8 @@ class LojaAdmin(admin.ModelAdmin):
 
     @staticmethod
     def protocolo(loja):
+        if not loja.proponente_id:
+            return "-"
         return loja.proponente.protocolo
 
     @staticmethod

--- a/sme_uniforme_apps/proponentes/tests/test_loja/test_model.py
+++ b/sme_uniforme_apps/proponentes/tests/test_loja/test_model.py
@@ -86,6 +86,19 @@ def test_admin_loja_exibe_comprovante_endereco(proponente, admin_user):
     )
 
 
+def test_admin_loja_protocolo_nao_quebra_sem_proponente():
+    loja_admin = LojaAdmin(Loja, AdminSite())
+    loja = Loja(
+        nome_fantasia="Loja Sem Proponente",
+        cep="01001-000",
+        endereco="Rua Teste",
+        bairro="Centro",
+        numero="100",
+    )
+
+    assert loja_admin.protocolo(loja) == "-"
+
+
 def test_loja_admin_form_configura_label_e_help_text():
     form = LojaAdminForm()
 

--- a/sme_uniforme_apps/triade/admin.py
+++ b/sme_uniforme_apps/triade/admin.py
@@ -1,10 +1,12 @@
 import json
+import logging
 
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.template.response import TemplateResponse
 from django.utils.dateparse import parse_date
 from django.utils.html import format_html
 
+from .exceptions import TriadeConfigError, TriadePermanentError, TriadeTransientError
 from .models import (
     TriadeCallback,
     TriadeConfiguracao,
@@ -12,6 +14,7 @@ from .models import (
     TriadeEstatistica,
     TriadeLote,
 )
+from .services import TriadeSubmissionService
 from .statuses import (
     TRIADE_CALLBACK_PROCESSING_LABELS,
     TRIADE_CALLBACK_PROCESSING_STATUSES,
@@ -19,12 +22,16 @@ from .statuses import (
     TRIADE_DECISOES,
     TRIADE_DOCUMENTO_STATUS_LABELS,
     TRIADE_DOCUMENTO_STATUSES,
+    TRIADE_LOTE_STATUSES_REPROCESSAVEIS,
     TRIADE_LOTE_STATUS_LABELS,
     TRIADE_LOTE_STATUSES,
     merge_known_and_observed_values,
     normalize_decisao,
     normalize_status,
 )
+from .tasks import reprocessar_lote_triade
+
+log = logging.getLogger(__name__)
 
 
 class TriadeReadOnlyAdmin(admin.ModelAdmin):
@@ -90,6 +97,7 @@ class TriadeLoteAdmin(TriadeReadOnlyAdmin):
         "proponente__cnpj",
         "proponente__razao_social",
     )
+    actions = ("retomar_processamento_na_triade", "sincronizar_com_triade")
 
     def get_fields(self, request, obj=None):
         fields = [field.name for field in self.model._meta.fields]
@@ -102,6 +110,139 @@ class TriadeLoteAdmin(TriadeReadOnlyAdmin):
         return self.render_large_text(obj.payload_envio)
 
     payload_envio_formatado.short_description = "Payload envio"
+
+    def retomar_processamento_na_triade(self, request, queryset):
+        try:
+            service = TriadeSubmissionService()
+        except TriadeConfigError as exc:
+            self.message_user(request, str(exc), level=messages.ERROR)
+            return
+
+        retomados = 0
+        ignorados_status = 0
+        ignorados_snapshot = 0
+        ignorados_erro_permanente = 0
+        falhas_enfileiramento = 0
+
+        for lote in queryset:
+            if normalize_status(lote.status) not in TRIADE_LOTE_STATUSES_REPROCESSAVEIS:
+                ignorados_status += 1
+                continue
+
+            blocker = service.get_retry_lote_blocker(lote)
+            if blocker:
+                if not lote.batch_id and not lote.payload_envio:
+                    ignorados_snapshot += 1
+                elif not lote.batch_id:
+                    ignorados_erro_permanente += 1
+                continue
+
+            try:
+                reprocessar_lote_triade.delay(lote.id)
+            except Exception:
+                log.exception(
+                    "Falha ao enfileirar retomada do lote TRIADE %s.",
+                    lote.external_batch_id,
+                )
+                falhas_enfileiramento += 1
+                continue
+
+            retomados += 1
+
+        if retomados:
+            self.message_user(
+                request,
+                "{} lote(s) agendado(s) para retomar o processamento na TRIADE.".format(
+                    retomados
+                ),
+                level=messages.SUCCESS,
+            )
+        if ignorados_status:
+            statuses_permitidos = ", ".join(TRIADE_LOTE_STATUSES_REPROCESSAVEIS)
+            self.message_user(
+                request,
+                "{} lote(s) ignorado(s) por status não reprocessável "
+                "(use apenas {}).".format(
+                    ignorados_status, statuses_permitidos
+                ),
+                level=messages.WARNING,
+            )
+        if ignorados_snapshot:
+            self.message_user(
+                request,
+                "{} lote(s) ignorado(s) por não terem batch_id nem payload_envio "
+                "persistido para retomar o mesmo lote.".format(ignorados_snapshot),
+                level=messages.WARNING,
+            )
+        if ignorados_erro_permanente:
+            self.message_user(
+                request,
+                "{} lote(s) ignorado(s) porque a criação anterior falhou com erro "
+                "permanente de payload/configuração. Corrija os dados e faça um novo envio.".format(
+                    ignorados_erro_permanente
+                ),
+                level=messages.WARNING,
+            )
+        if falhas_enfileiramento:
+            self.message_user(
+                request,
+                "{} lote(s) não puderam ser enfileirados para retomada. "
+                "Verifique os logs da aplicação.".format(falhas_enfileiramento),
+                level=messages.ERROR,
+            )
+
+    retomar_processamento_na_triade.short_description = (
+        "Retomar processamento na TRIADE (mesmo lote/snapshot)"
+    )
+
+    def sincronizar_com_triade(self, request, queryset):
+        try:
+            service = TriadeSubmissionService()
+        except TriadeConfigError as exc:
+            self.message_user(request, str(exc), level=messages.ERROR)
+            return
+
+        sincronizados = 0
+        sem_batch = 0
+        com_erro = 0
+
+        for lote in queryset:
+            if not lote.batch_id:
+                sem_batch += 1
+                continue
+
+            try:
+                service.sync_lote(lote)
+            except (TriadePermanentError, TriadeTransientError):
+                com_erro += 1
+                continue
+
+            sincronizados += 1
+
+        if sincronizados:
+            self.message_user(
+                request,
+                "{} lote(s) sincronizado(s) com a TRIADE.".format(sincronizados),
+                level=messages.SUCCESS,
+            )
+        if sem_batch:
+            self.message_user(
+                request,
+                "{} lote(s) ignorado(s) por não terem batch_id "
+                "(não foram aceitos pela TRIADE).".format(sem_batch),
+                level=messages.WARNING,
+            )
+        if com_erro:
+            self.message_user(
+                request,
+                "{} lote(s) com erro na consulta. Verifique ultimo_erro "
+                "e tente novamente.".format(com_erro),
+                level=messages.WARNING,
+            )
+
+    sincronizar_com_triade.short_description = (
+        "Sincronizar status e documentos com a TRIADE (GET /batches/{id})"
+    )
 
 
 @admin.register(TriadeDocumento)

--- a/sme_uniforme_apps/triade/callbacks.py
+++ b/sme_uniforme_apps/triade/callbacks.py
@@ -5,7 +5,7 @@ import logging
 import uuid
 
 from django.conf import settings
-from django.db import transaction
+from django.db import OperationalError, transaction
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -13,6 +13,7 @@ from django.utils.dateparse import parse_datetime
 from sme_uniforme_apps.proponentes.models import Anexo
 
 from .exceptions import (
+    TriadeCallbackTransientError,
     TriadeConfigError,
     TriadePermanentError,
     TriadeRequestError,
@@ -86,14 +87,14 @@ class TriadeCallbackService:
             raise TriadeSignatureError("Assinatura TRIADE invalida.")
 
     def process_callback(self, callback_id):
-        callback = TriadeCallback.objects.get(pk=callback_id)
-        if callback.status_processamento in (
-            self.STATUS_PROCESSADO,
-            self.STATUS_DUPLICADO,
-        ):
-            return callback
-
         try:
+            callback = TriadeCallback.objects.get(pk=callback_id)
+            if callback.status_processamento in (
+                self.STATUS_PROCESSADO,
+                self.STATUS_DUPLICADO,
+            ):
+                return callback
+
             with transaction.atomic():
                 callback = TriadeCallback.objects.select_for_update().get(
                     pk=callback_id
@@ -144,6 +145,25 @@ class TriadeCallbackService:
                     ),
                 )
                 return callback
+        except OperationalError as exc:
+            log.warning(
+                "Falha transitória de banco de dados durante o processamento do callback TRIADE %s: %s. Nova tentativa será realizada.",
+                callback_id,
+                exc,
+            )
+            try:
+                queryset_update_with_alterado_em(
+                    TriadeCallback.objects.filter(pk=callback_id),
+                    status_processamento=self.STATUS_RECEBIDO,
+                    erro="Falha transitória: {}".format(exc),
+                )
+            except OperationalError:
+                log.warning(
+                    "Não foi possível restaurar o status do callback TRIADE %s após a ocorrência de uma falha transitória.",
+                    callback_id,
+                    exc_info=True,
+                )
+            raise TriadeCallbackTransientError(str(exc)) from exc
         except Exception as exc:
             log.exception("Falha ao processar callback TRIADE %s.", callback_id)
             queryset_update_with_alterado_em(

--- a/sme_uniforme_apps/triade/exceptions.py
+++ b/sme_uniforme_apps/triade/exceptions.py
@@ -20,3 +20,7 @@ class TriadeSignatureError(TriadePermanentError):
 
 class TriadeTransientError(TriadeError):
     pass
+
+
+class TriadeCallbackTransientError(TriadeError):
+    pass

--- a/sme_uniforme_apps/triade/services.py
+++ b/sme_uniforme_apps/triade/services.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from django.conf import settings
 from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 
 from sme_uniforme_apps.proponentes.models import Proponente
 
@@ -15,6 +16,7 @@ from .models import TriadeDocumento, TriadeLote
 from .persistence import queryset_update_with_alterado_em, save_with_alterado_em
 from .runtime import get_triade_runtime_config
 from .statuses import (
+    TRIADE_LOTE_STATUSES_REPROCESSAVEIS,
     TRIADE_LOTE_TERMINAL_STATUSES,
     normalize_decisao,
     normalize_status,
@@ -180,6 +182,97 @@ class TriadeSubmissionService:
     def build_external_batch_id(self, proponente):
         return "proponente-{}".format(proponente.uuid)
 
+    def retry_lote_id(self, lote_id):
+        try:
+            lote = TriadeLote.objects.get(pk=lote_id)
+        except TriadeLote.DoesNotExist:
+            raise TriadePermanentError(
+                "Lote TRIADE {} nao encontrado para retomada de processamento.".format(
+                    lote_id
+                )
+            )
+
+        return self.retry_lote(lote)
+
+    def retry_lote(self, lote):
+        blocker = self.get_retry_lote_blocker(lote)
+        if blocker:
+            raise TriadePermanentError(blocker)
+
+        if lote.batch_id:
+            self._iniciar_pipeline(lote)
+            lote.refresh_from_db()
+            return lote
+
+        payload = self._deserialize_json(lote.payload_envio, "payload_envio")
+        self._criar_lote_externo(lote, payload)
+        lote.refresh_from_db()
+        self._iniciar_pipeline(lote)
+        lote.refresh_from_db()
+        return lote
+
+    def get_retry_lote_blocker(self, lote):
+        status_normalized = normalize_status(lote.status)
+        if status_normalized not in TRIADE_LOTE_STATUSES_REPROCESSAVEIS:
+            return "Lote TRIADE {} esta com status {} e nao pode ser retomado.".format(
+                lote.external_batch_id,
+                lote.status,
+            )
+
+        if lote.batch_id:
+            return None
+
+        if not lote.payload_envio:
+            return (
+                "Lote TRIADE {} nao pode ser retomado sem batch_id ou payload_envio "
+                "persistido."
+            ).format(lote.external_batch_id)
+
+        if self._can_retry_create_same_snapshot(lote):
+            return None
+
+        return (
+            "Lote TRIADE {} falhou na criacao com HTTP {}. Isso indica erro "
+            "permanente de payload/configuracao; nao retome o mesmo snapshot."
+        ).format(lote.external_batch_id, lote.status_http_criacao)
+
+    def _can_retry_create_same_snapshot(self, lote):
+        status_code = lote.status_http_criacao
+        if status_code is None:
+            return True
+        if 200 <= status_code < 300:
+            return True
+        if status_code == 429:
+            return True
+        if 500 <= status_code <= 599:
+            return True
+        return False
+
+    def sync_lote(self, lote):
+        if not lote.batch_id:
+            raise TriadePermanentError(
+                "Lote TRIADE {} nao possui batch_id para sincronizacao.".format(
+                    lote.external_batch_id
+                )
+            )
+
+        try:
+            response = self.client.get_batch(str(lote.batch_id))
+        except TriadeTransientError as exc:
+            lote.ultimo_erro = str(exc)
+            save_with_alterado_em(lote, ("ultimo_erro",))
+            raise
+
+        response_data = self._response_data_as_dict(response)
+        if response.is_success:
+            self._apply_batch_sync_to_lote(lote, response_data)
+            self._sync_documentos_from_batch(lote, response_data.get("documents", []))
+            return lote
+
+        lote.ultimo_erro = self._build_error_message("consulta do lote", response)
+        save_with_alterado_em(lote, ("ultimo_erro",))
+        self._raise_for_response("consulta do lote", response)
+
     def _criar_lote_externo(self, lote, payload):
         response = self.client.create_batch(payload)
         lote.status_http_criacao = response.status_code
@@ -334,6 +427,66 @@ class TriadeSubmissionService:
                     **defaults
                 )
 
+    def _apply_batch_sync_to_lote(self, lote, response_data):
+        normalized_status = normalize_status(response_data.get("status"))
+        if normalized_status:
+            lote.status = normalized_status
+
+        metadata = response_data.get("metadata")
+        if metadata is not None:
+            lote.metadata = self._serialize_json(metadata)
+
+        lote.ultimo_erro = None
+        save_with_alterado_em(lote, ("status", "metadata", "ultimo_erro"))
+
+    def _sync_documentos_from_batch(self, lote, documents):
+        for document_payload in documents:
+            external_document_id = document_payload.get("external_document_id")
+            if not external_document_id:
+                continue
+
+            defaults = {}
+            normalized_status = normalize_status(document_payload.get("status"))
+            normalized_decisao = normalize_decisao(document_payload.get("decisao"))
+
+            if normalized_status:
+                defaults["status"] = normalized_status
+            if normalized_decisao:
+                defaults["decisao"] = normalized_decisao
+
+            document_id = self._parse_uuid(
+                document_payload.get("document_id"),
+                "documents[].document_id",
+                required=False,
+            )
+            if document_id:
+                defaults["document_id"] = document_id
+
+            processed_at = self._parse_datetime(document_payload.get("processed_at"))
+            if processed_at:
+                defaults["processed_at"] = processed_at
+
+            for field_name in (
+                "external_document_type",
+                "document_type",
+                "title",
+                "justificativa",
+                "error",
+            ):
+                if field_name in document_payload:
+                    defaults[field_name] = document_payload.get(field_name) or None
+
+            if document_payload.get("metadata") is not None:
+                defaults["metadata"] = self._serialize_json(
+                    document_payload.get("metadata")
+                )
+
+            TriadeDocumento.objects.update_or_create(
+                lote=lote,
+                external_document_id=external_document_id,
+                defaults=defaults,
+            )
+
     def _registrar_erro_no_lote(self, lote, response, etapa, update_fields):
         lote.status = self.STATUS_ERRO
         lote.ultimo_erro = self._build_error_message(etapa, response)
@@ -387,6 +540,17 @@ class TriadeSubmissionService:
         return json.dumps(
             value, ensure_ascii=False, separators=(",", ":"), sort_keys=True
         )
+
+    def _parse_datetime(self, value):
+        if not value:
+            return None
+
+        parsed = parse_datetime(value)
+        if not parsed:
+            return None
+        if timezone.is_naive(parsed):
+            return timezone.make_aware(parsed, timezone.get_current_timezone())
+        return parsed
 
     def _get_anexos_para_envio(self, proponente):
         queryset = proponente.anexos.select_related("tipo_documento").order_by("id")

--- a/sme_uniforme_apps/triade/services.py
+++ b/sme_uniforme_apps/triade/services.py
@@ -14,7 +14,11 @@ from .exceptions import TriadeConfigError, TriadePermanentError, TriadeTransient
 from .models import TriadeDocumento, TriadeLote
 from .persistence import queryset_update_with_alterado_em, save_with_alterado_em
 from .runtime import get_triade_runtime_config
-from .statuses import normalize_decisao, normalize_status
+from .statuses import (
+    TRIADE_LOTE_TERMINAL_STATUSES,
+    normalize_decisao,
+    normalize_status,
+)
 
 log = logging.getLogger(__name__)
 
@@ -234,6 +238,7 @@ class TriadeSubmissionService:
 
         if response.is_success or response.status_code == 409:
             response_data = self._response_data_as_dict(response)
+            normalized_status = normalize_status(response_data.get("status"))
             lote.submission_id = (
                 self._parse_uuid(
                     response_data.get("submission_id"),
@@ -245,9 +250,10 @@ class TriadeSubmissionService:
             lote.analysis_desk_id = (
                 response_data.get("analysis_desk_id") or lote.analysis_desk_id
             )
-            lote.status = (
-                normalize_status(response_data.get("status")) or self.STATUS_PROCESSANDO
-            )
+            if normalized_status:
+                lote.status = normalized_status
+            elif lote.status not in TRIADE_LOTE_TERMINAL_STATUSES:
+                lote.status = self.STATUS_PROCESSANDO
             lote.iniciado_em = lote.iniciado_em or timezone.now()
             lote.ultimo_erro = None
             save_with_alterado_em(

--- a/sme_uniforme_apps/triade/statuses.py
+++ b/sme_uniforme_apps/triade/statuses.py
@@ -7,6 +7,12 @@ TRIADE_LOTE_STATUSES = (
     "error",
 )
 
+TRIADE_LOTE_TERMINAL_STATUSES = (
+    "pending_review",
+    "completed",
+    "error",
+)
+
 TRIADE_DOCUMENTO_STATUSES = (
     "received",
     "processing",

--- a/sme_uniforme_apps/triade/statuses.py
+++ b/sme_uniforme_apps/triade/statuses.py
@@ -13,6 +13,12 @@ TRIADE_LOTE_TERMINAL_STATUSES = (
     "error",
 )
 
+TRIADE_LOTE_STATUSES_REPROCESSAVEIS = (
+    "error",
+    "payload_ready",
+    "received",
+)
+
 TRIADE_DOCUMENTO_STATUSES = (
     "received",
     "processing",

--- a/sme_uniforme_apps/triade/tasks.py
+++ b/sme_uniforme_apps/triade/tasks.py
@@ -1,7 +1,7 @@
 from celery import shared_task
 
 from .callbacks import TriadeCallbackService
-from .exceptions import TriadeTransientError
+from .exceptions import TriadeCallbackTransientError, TriadeTransientError
 from .services import TriadeSubmissionService
 
 
@@ -32,8 +32,13 @@ def orquestrar_envio_lote_triade(
     }
 
 
-@shared_task
-def processar_callback_triade(callback_id):
+@shared_task(
+    bind=True,
+    autoretry_for=(TriadeCallbackTransientError,),
+    retry_backoff=2,
+    retry_kwargs={"max_retries": 6},
+)
+def processar_callback_triade(self, callback_id):
     callback = TriadeCallbackService().process_callback(callback_id)
     return {
         "callback_id": callback.id,

--- a/sme_uniforme_apps/triade/tasks.py
+++ b/sme_uniforme_apps/triade/tasks.py
@@ -34,6 +34,24 @@ def orquestrar_envio_lote_triade(
 
 @shared_task(
     bind=True,
+    autoretry_for=(TriadeTransientError,),
+    retry_backoff=2,
+    retry_kwargs={"max_retries": 6},
+)
+def reprocessar_lote_triade(self, lote_id):
+    lote = TriadeSubmissionService().retry_lote_id(lote_id)
+    return {
+        "lote_id": lote.id,
+        "lote_uuid": str(lote.uuid),
+        "external_batch_id": lote.external_batch_id,
+        "batch_id": str(lote.batch_id) if lote.batch_id else None,
+        "submission_id": str(lote.submission_id) if lote.submission_id else None,
+        "status": lote.status,
+    }
+
+
+@shared_task(
+    bind=True,
     autoretry_for=(TriadeCallbackTransientError,),
     retry_backoff=2,
     retry_kwargs={"max_retries": 6},

--- a/sme_uniforme_apps/triade/tests/test_admin.py
+++ b/sme_uniforme_apps/triade/tests/test_admin.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import json
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -8,6 +9,7 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from model_bakery import baker
 
+from sme_uniforme_apps.triade.exceptions import TriadeTransientError
 from sme_uniforme_apps.triade.models import (
     TriadeCallback,
     TriadeConfiguracao,
@@ -172,3 +174,477 @@ def test_tela_admin_de_estatisticas_triade_consolida_quantitativos_e_filtra(
         item["value"] for item in response.context["catalog"]["lotes"]["status"]
     ]
     assert response.context["recent_lotes"][0].external_batch_id == "lote-concluido"
+
+
+def _changelist_url():
+    return reverse("admin:triade_triadelote_changelist")
+
+
+@patch("sme_uniforme_apps.triade.admin.reprocessar_lote_triade.delay")
+def test_action_retomar_processamento_agenda_task_sem_limpar_estado(
+    mock_delay, admin_client_logado, settings, proponente_triade
+):
+    """Retomada do lote deve apenas agendar o reprocessamento do mesmo
+    snapshot local, sem limpar batch_id, payload ou documentos.
+    """
+    configure_triade_settings(settings)
+    lote = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="proponente-{}".format(proponente_triade.uuid),
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="error",
+        batch_id=uuid4(),
+        submission_id=uuid4(),
+        payload_envio='{"applicant":{"name":"antigo"}}',
+        metadata='{"k":"v"}',
+        status_http_criacao=201,
+        resposta_criacao='{"ok":true}',
+        status_http_inicio=422,
+        resposta_inicio='{"detail":"erro"}',
+        ultimo_erro="Falha no /start",
+        enviado_em="2026-01-01 00:00:00+00:00",
+        iniciado_em="2026-01-01 00:00:01+00:00",
+    )
+    TriadeDocumento.objects.create(
+        lote=lote,
+        external_document_id="doc-1",
+        document_type="cartao_cnpj",
+    )
+
+    response = admin_client_logado.post(
+        _changelist_url(),
+        data={
+            "action": "retomar_processamento_na_triade",
+            "_selected_action": [str(lote.pk)],
+        },
+    )
+
+    assert response.status_code == 302
+    assert mock_delay.call_count == 1
+    args = mock_delay.call_args.args
+    assert len(args) == 1
+    assert args[0] == lote.id
+
+    lote.refresh_from_db()
+    assert lote.payload_envio == '{"applicant":{"name":"antigo"}}'
+    assert json.loads(lote.metadata) == {"k": "v"}
+    assert lote.batch_id is not None
+    assert lote.submission_id is not None
+    assert lote.status_http_criacao == 201
+    assert lote.status_http_inicio == 422
+    assert lote.ultimo_erro == "Falha no /start"
+    assert lote.enviado_em is not None
+    assert lote.iniciado_em is not None
+    assert TriadeDocumento.objects.filter(lote=lote).count() == 1
+
+
+@patch("sme_uniforme_apps.triade.admin.reprocessar_lote_triade.delay")
+def test_action_retomar_processamento_ignora_status_terminal(
+    mock_delay, admin_client_logado, settings, proponente_triade
+):
+    """Lote em status terminal não entra na retomada do mesmo snapshot."""
+    configure_triade_settings(settings)
+    lote = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="lote-concluido",
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="completed",
+        batch_id=uuid4(),
+    )
+
+    response = admin_client_logado.post(
+        _changelist_url(),
+        data={
+            "action": "retomar_processamento_na_triade",
+            "_selected_action": [str(lote.pk)],
+        },
+    )
+
+    assert response.status_code == 302
+    assert mock_delay.call_count == 0
+
+    lote.refresh_from_db()
+    assert lote.status == "completed"
+    assert lote.batch_id is not None
+
+
+@patch("sme_uniforme_apps.triade.admin.reprocessar_lote_triade.delay")
+def test_action_retomar_processamento_ignora_lote_sem_batch_e_sem_snapshot(
+    mock_delay, admin_client_logado, settings, proponente_triade
+):
+    """Sem batch_id e sem payload persistido, nao ha como retomar o
+    mesmo lote na TRIADE.
+    """
+    configure_triade_settings(settings)
+    lote = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="lote-sem-snapshot",
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="error",
+        payload_envio=None,
+        batch_id=None,
+    )
+
+    response = admin_client_logado.post(
+        _changelist_url(),
+        data={
+            "action": "retomar_processamento_na_triade",
+            "_selected_action": [str(lote.pk)],
+        },
+    )
+
+    assert response.status_code == 302
+    assert mock_delay.call_count == 0
+
+    lote.refresh_from_db()
+    assert lote.status == "error"
+
+
+@patch("sme_uniforme_apps.triade.admin.reprocessar_lote_triade.delay")
+def test_action_retomar_processamento_ignora_erro_permanente_de_criacao(
+    mock_delay, admin_client_logado, settings, proponente_triade
+):
+    configure_triade_settings(settings)
+    lote = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="lote-erro-permanente",
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="error",
+        payload_envio='{"documents":[]}',
+        batch_id=None,
+        status_http_criacao=422,
+    )
+
+    response = admin_client_logado.post(
+        _changelist_url(),
+        data={
+            "action": "retomar_processamento_na_triade",
+            "_selected_action": [str(lote.pk)],
+        },
+    )
+
+    assert response.status_code == 302
+    assert mock_delay.call_count == 0
+
+    lote.refresh_from_db()
+    assert lote.status == "error"
+
+
+@patch("sme_uniforme_apps.triade.admin.reprocessar_lote_triade.delay")
+def test_action_retomar_processamento_processa_lote_misto(
+    mock_delay, admin_client_logado, settings, proponente_triade
+):
+    """Mistura de lotes: um em error com snapshot (agenda), um em
+    completed (ignora), um sem batch nem snapshot (ignora).
+    """
+    configure_triade_settings(settings)
+    lote_reenviavel = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="proponente-{}".format(proponente_triade.uuid),
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="error",
+        batch_id=uuid4(),
+        payload_envio='{"documents":[]}',
+    )
+    lote_terminal = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="lote-terminal",
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="completed",
+        batch_id=uuid4(),
+    )
+    lote_sem_snapshot = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="lote-sem-snapshot",
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="payload_ready",
+        payload_envio=None,
+        batch_id=None,
+    )
+
+    response = admin_client_logado.post(
+        _changelist_url(),
+        data={
+            "action": "retomar_processamento_na_triade",
+            "_selected_action": [
+                str(lote_reenviavel.pk),
+                str(lote_terminal.pk),
+                str(lote_sem_snapshot.pk),
+            ],
+        },
+    )
+
+    assert response.status_code == 302
+    assert mock_delay.call_count == 1
+    args = mock_delay.call_args.args
+    assert len(args) == 1
+    assert args[0] == lote_reenviavel.id
+
+    lote_reenviavel.refresh_from_db()
+    lote_terminal.refresh_from_db()
+    lote_sem_snapshot.refresh_from_db()
+    assert lote_reenviavel.batch_id is not None
+    assert lote_terminal.status == "completed"
+    assert lote_terminal.batch_id is not None
+    assert lote_sem_snapshot.status == "payload_ready"
+
+
+class _DummyTriadeResponse:
+    def __init__(self, status_code, data=None, text=None):
+        self.status_code = status_code
+        self.data = data
+        self.text = text if text is not None else json.dumps(data or {})
+
+    @property
+    def is_success(self):
+        return 200 <= self.status_code < 300
+
+    def json(self):
+        if self.data is None:
+            raise ValueError("response without json")
+        return self.data
+
+
+@patch("sme_uniforme_apps.triade.services.TriadeHttpClient.get_batch")
+def test_action_sincronizar_atualiza_status_metadata_e_documentos(
+    mock_get_batch, admin_client_logado, settings, proponente_triade, anexo_triade
+):
+    """Sync bem-sucedido: status e metadata do lote sao atualizados,
+    e os TriadeDocumento do lote ganham status/processed_at vindos
+    do GET.
+    """
+    configure_triade_settings(settings)
+    batch_id = uuid4()
+    document_id = uuid4()
+    lote = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="proponente-{}".format(proponente_triade.uuid),
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="processing",
+        batch_id=batch_id,
+        decisao_parecer="APROVADO",
+        parecer_texto="Parecer original do callback",
+    )
+    documento_local = TriadeDocumento.objects.create(
+        lote=lote,
+        anexo=anexo_triade,
+        external_document_id=str(anexo_triade.uuid),
+        document_type="cartao_cnpj",
+        status="received",
+    )
+    decisao_original = lote.decisao_parecer
+
+    mock_get_batch.return_value = _DummyTriadeResponse(
+        200,
+        {
+            "batch_id": str(batch_id),
+            "status": "completed",
+            "metadata": {"edital": "2026", "atualizado": "sim"},
+            "documents": [
+                {
+                    "external_document_id": str(anexo_triade.uuid),
+                    "document_id": str(document_id),
+                    "status": "completed",
+                    "processed_at": "2026-05-31T12:00:00Z",
+                    "error": None,
+                    "metadata": {"origem": "sync"},
+                }
+            ],
+        },
+    )
+
+    response = admin_client_logado.post(
+        _changelist_url(),
+        data={
+            "action": "sincronizar_com_triade",
+            "_selected_action": [str(lote.pk)],
+        },
+    )
+
+    assert response.status_code == 302
+    assert mock_get_batch.call_count == 1
+    assert mock_get_batch.call_args.args == (str(batch_id),)
+
+    lote.refresh_from_db()
+    assert lote.status == "completed"
+    assert json.loads(lote.metadata) == {"edital": "2026", "atualizado": "sim"}
+    assert lote.ultimo_erro is None
+    assert lote.decisao_parecer == decisao_original
+
+    documento_local.refresh_from_db()
+    assert documento_local.status == "completed"
+    assert documento_local.document_id == document_id
+    assert documento_local.processed_at is not None
+    assert json.loads(documento_local.metadata) == {"origem": "sync"}
+
+
+@patch("sme_uniforme_apps.triade.services.TriadeHttpClient.get_batch")
+def test_action_sincronizar_ignora_lote_sem_batch_id(
+    mock_get_batch, admin_client_logado, settings, proponente_triade
+):
+    """Lote sem batch_id (TRIADE nunca aceitou) NAO pode ser
+    consultado por GET.
+    """
+    configure_triade_settings(settings)
+    lote = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="lote-sem-batch",
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="payload_ready",
+    )
+
+    response = admin_client_logado.post(
+        _changelist_url(),
+        data={
+            "action": "sincronizar_com_triade",
+            "_selected_action": [str(lote.pk)],
+        },
+    )
+
+    assert response.status_code == 302
+    assert mock_get_batch.call_count == 0
+
+    lote.refresh_from_db()
+    assert lote.status == "payload_ready"
+
+
+@patch("sme_uniforme_apps.triade.services.TriadeHttpClient.get_batch")
+def test_action_sincronizar_registra_erro_em_resposta_nao_sucesso(
+    mock_get_batch, admin_client_logado, settings, proponente_triade
+):
+    """Resposta 5xx ou 404 do TRIADE: registra em ultimo_erro e
+    nao altera status do lote.
+    """
+    configure_triade_settings(settings)
+    lote = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="proponente-{}".format(proponente_triade.uuid),
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="processing",
+        batch_id=uuid4(),
+    )
+
+    mock_get_batch.return_value = _DummyTriadeResponse(
+        503, data=None, text="upstream down"
+    )
+
+    response = admin_client_logado.post(
+        _changelist_url(),
+        data={
+            "action": "sincronizar_com_triade",
+            "_selected_action": [str(lote.pk)],
+        },
+    )
+
+    assert response.status_code == 302
+    assert mock_get_batch.call_count == 1
+
+    lote.refresh_from_db()
+    assert lote.status == "processing"
+    assert "503" in lote.ultimo_erro
+
+
+@patch("sme_uniforme_apps.triade.services.TriadeHttpClient.get_batch")
+def test_action_sincronizar_registra_erro_transiente_de_comunicacao(
+    mock_get_batch, admin_client_logado, settings, proponente_triade
+):
+    configure_triade_settings(settings)
+    lote = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="lote-timeout",
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="processing",
+        batch_id=uuid4(),
+    )
+
+    mock_get_batch.side_effect = TriadeTransientError("timeout upstream")
+
+    response = admin_client_logado.post(
+        _changelist_url(),
+        data={
+            "action": "sincronizar_com_triade",
+            "_selected_action": [str(lote.pk)],
+        },
+    )
+
+    assert response.status_code == 302
+    assert mock_get_batch.call_count == 1
+
+    lote.refresh_from_db()
+    assert lote.status == "processing"
+    assert "timeout upstream" in lote.ultimo_erro
+
+
+@patch("sme_uniforme_apps.triade.services.TriadeHttpClient.get_batch")
+def test_action_sincronizar_processa_lote_misto(
+    mock_get_batch, admin_client_logado, settings, proponente_triade
+):
+    """Mistura: um com batch_id e GET ok, um sem batch_id, um com
+    GET retornando 404.
+    """
+    configure_triade_settings(settings)
+    lote_sync = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="lote-sync",
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="processing",
+        batch_id=uuid4(),
+    )
+    lote_sem_batch = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="lote-sem-batch",
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="error",
+    )
+    lote_404 = TriadeLote.objects.create(
+        proponente=proponente_triade,
+        external_batch_id="lote-404",
+        source_system="portal_uniforme",
+        schema_version="1.0",
+        status="processing",
+        batch_id=uuid4(),
+    )
+
+    def fake_get_batch(batch_id_str):
+        if str(lote_sync.batch_id) == batch_id_str:
+            return _DummyTriadeResponse(
+                200, {"batch_id": batch_id_str, "status": "completed"}
+            )
+        return _DummyTriadeResponse(404, data=None, text="not found")
+
+    mock_get_batch.side_effect = fake_get_batch
+
+    response = admin_client_logado.post(
+        _changelist_url(),
+        data={
+            "action": "sincronizar_com_triade",
+            "_selected_action": [
+                str(lote_sync.pk),
+                str(lote_sem_batch.pk),
+                str(lote_404.pk),
+            ],
+        },
+    )
+
+    assert response.status_code == 302
+    assert mock_get_batch.call_count == 2
+
+    lote_sync.refresh_from_db()
+    lote_sem_batch.refresh_from_db()
+    lote_404.refresh_from_db()
+    assert lote_sync.status == "completed"
+    assert lote_sem_batch.status == "error"
+    assert "404" in lote_404.ultimo_erro

--- a/sme_uniforme_apps/triade/tests/test_callback_service.py
+++ b/sme_uniforme_apps/triade/tests/test_callback_service.py
@@ -1,11 +1,14 @@
 import hashlib
 import hmac
 import json
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+from django.db import OperationalError
 
 from sme_uniforme_apps.triade.callbacks import TriadeCallbackService
+from sme_uniforme_apps.triade.exceptions import TriadeCallbackTransientError
 from sme_uniforme_apps.triade.models import TriadeCallback, TriadeDocumento
 from sme_uniforme_apps.triade.services import TriadeSubmissionService
 
@@ -194,3 +197,127 @@ def test_process_callback_normaliza_status_e_decisao_recebidos_do_triade(
     assert documento.status == "pending_review"
     assert documento.decisao == "PENDENCIA"
     assert anexo_triade.status_ia == "PENDENCIA"
+
+
+def test_process_callback_reseta_status_e_retry_em_operational_error(
+    settings, proponente_triade, loja_primeira, anexo_triade
+):
+    """Garante que erro transitório de banco não deixa o callback perdido:
+    status volta para RECEBIDO e exceção transitória é levantada para o
+    celery retentar via autoretry_for.
+    """
+    configure_triade_settings(settings)
+    submission_service = TriadeSubmissionService()
+    lote = submission_service.prepare_lote_envio(proponente_triade).lote
+    batch_id = uuid4()
+    submission_id = uuid4()
+    payload = build_callback_payload(lote, anexo_triade, batch_id, submission_id)
+    raw_payload = json.dumps(payload).encode("utf-8")
+
+    callback = TriadeCallback.objects.create(
+        delivery_id=uuid4(),
+        lote=lote,
+        external_batch_id=lote.external_batch_id,
+        batch_id=batch_id,
+        submission_id=submission_id,
+        assinatura_recebida=sign_payload(settings.TRIADE_HMAC_SECRET, raw_payload),
+        payload_bruto=raw_payload.decode("utf-8"),
+        payload_hash=hashlib.sha256(raw_payload).hexdigest(),
+        status_processamento=TriadeCallbackService.STATUS_RECEBIDO,
+    )
+
+    with patch(
+        "sme_uniforme_apps.triade.callbacks.TriadeCallbackService._apply_payload_to_lote",
+        side_effect=OperationalError("connection lost"),
+    ):
+        with pytest.raises(TriadeCallbackTransientError):
+            TriadeCallbackService().process_callback(callback.id)
+
+    callback.refresh_from_db()
+    assert callback.status_processamento == TriadeCallbackService.STATUS_RECEBIDO
+    assert callback.processado_em is None
+    assert "Falha transitória" in callback.erro
+
+
+def test_process_callback_mantem_excecao_transiente_quando_reset_status_falha(
+    settings, proponente_triade, loja_primeira, anexo_triade
+):
+    configure_triade_settings(settings)
+    submission_service = TriadeSubmissionService()
+    lote = submission_service.prepare_lote_envio(proponente_triade).lote
+    batch_id = uuid4()
+    submission_id = uuid4()
+    payload = build_callback_payload(lote, anexo_triade, batch_id, submission_id)
+    raw_payload = json.dumps(payload).encode("utf-8")
+
+    callback = TriadeCallback.objects.create(
+        delivery_id=uuid4(),
+        lote=lote,
+        external_batch_id=lote.external_batch_id,
+        batch_id=batch_id,
+        submission_id=submission_id,
+        assinatura_recebida=sign_payload(settings.TRIADE_HMAC_SECRET, raw_payload),
+        payload_bruto=raw_payload.decode("utf-8"),
+        payload_hash=hashlib.sha256(raw_payload).hexdigest(),
+        status_processamento=TriadeCallbackService.STATUS_RECEBIDO,
+    )
+
+    with patch(
+        "sme_uniforme_apps.triade.callbacks.TriadeCallbackService._apply_payload_to_lote",
+        side_effect=OperationalError("connection lost"),
+    ):
+        with patch(
+            "sme_uniforme_apps.triade.callbacks.queryset_update_with_alterado_em",
+            side_effect=OperationalError("update failed"),
+        ):
+            with pytest.raises(TriadeCallbackTransientError):
+                TriadeCallbackService().process_callback(callback.id)
+
+
+def test_process_callback_marca_status_erro_em_excecao_permanente(
+    settings, proponente_triade, loja_primeira, anexo_triade
+):
+    """Garante que bug de programação (exceção não transitória) NÃO é
+    retentado: status vai para ERRO com processado_em preenchido.
+    """
+    configure_triade_settings(settings)
+    submission_service = TriadeSubmissionService()
+    lote = submission_service.prepare_lote_envio(proponente_triade).lote
+    batch_id = uuid4()
+    submission_id = uuid4()
+    payload = build_callback_payload(lote, anexo_triade, batch_id, submission_id)
+    raw_payload = json.dumps(payload).encode("utf-8")
+
+    callback = TriadeCallback.objects.create(
+        delivery_id=uuid4(),
+        lote=lote,
+        external_batch_id=lote.external_batch_id,
+        batch_id=batch_id,
+        submission_id=submission_id,
+        assinatura_recebida=sign_payload(settings.TRIADE_HMAC_SECRET, raw_payload),
+        payload_bruto=raw_payload.decode("utf-8"),
+        payload_hash=hashlib.sha256(raw_payload).hexdigest(),
+        status_processamento=TriadeCallbackService.STATUS_RECEBIDO,
+    )
+
+    with patch(
+        "sme_uniforme_apps.triade.callbacks.TriadeCallbackService._apply_payload_to_lote",
+        side_effect=KeyError("bug de programacao"),
+    ):
+        with pytest.raises(KeyError):
+            TriadeCallbackService().process_callback(callback.id)
+
+    callback.refresh_from_db()
+    assert callback.status_processamento == TriadeCallbackService.STATUS_ERRO
+    assert callback.processado_em is not None
+
+
+def test_task_processar_callback_triade_tem_autoretry_configurado():
+    """Garante que a task tem autoretry_for configurado para
+    TriadeCallbackTransientError, com limite máximo de tentativas.
+    """
+    from sme_uniforme_apps.triade.tasks import processar_callback_triade
+
+    assert TriadeCallbackTransientError in processar_callback_triade.autoretry_for
+    assert processar_callback_triade.retry_kwargs.get("max_retries") == 6
+    assert processar_callback_triade.retry_backoff == 2

--- a/sme_uniforme_apps/triade/tests/test_submission_service.py
+++ b/sme_uniforme_apps/triade/tests/test_submission_service.py
@@ -245,3 +245,25 @@ def test_dispatch_trata_409_do_start_como_sucesso_idempotente(
     assert lote.status == "processing"
     assert lote.iniciado_em is not None
     assert lote.ultimo_erro is None
+
+
+@patch("sme_uniforme_apps.triade.client.requests.Session.request")
+def test_dispatch_com_409_no_start_preserva_status_terminal_do_lote(
+    mock_request, settings, proponente_triade, loja_primeira, anexo_triade
+):
+    configure_triade_settings(settings)
+    service = TriadeSubmissionService()
+    prepared = service.prepare_lote_envio(proponente_triade)
+    lote = prepared.lote
+    lote.batch_id = uuid4()
+    lote.status = "completed"
+    lote.save(update_fields=("batch_id", "status"))
+    mock_request.side_effect = [DummyResponse(409, {"detail": "pipeline ja iniciado"})]
+
+    lote = service.dispatch_proponente_uuid(str(proponente_triade.uuid))
+    lote.refresh_from_db()
+
+    assert mock_request.call_count == 1
+    assert lote.status_http_inicio == 409
+    assert lote.status == "completed"
+    assert lote.ultimo_erro is None

--- a/sme_uniforme_apps/triade/tests/test_submission_service.py
+++ b/sme_uniforme_apps/triade/tests/test_submission_service.py
@@ -6,6 +6,10 @@ import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from model_bakery import baker
 
+from sme_uniforme_apps.triade.exceptions import (
+    TriadePermanentError,
+    TriadeTransientError,
+)
 from sme_uniforme_apps.triade.models import TriadeConfiguracao, TriadeDocumento
 from sme_uniforme_apps.triade.services import TriadeSubmissionService
 
@@ -267,3 +271,99 @@ def test_dispatch_com_409_no_start_preserva_status_terminal_do_lote(
     assert lote.status_http_inicio == 409
     assert lote.status == "completed"
     assert lote.ultimo_erro is None
+
+
+@patch("sme_uniforme_apps.triade.client.requests.Session.request")
+def test_retry_lote_sem_batch_id_reusa_snapshot_persistido(
+    mock_request, settings, proponente_triade, loja_primeira, anexo_triade
+):
+    configure_triade_settings(settings)
+    service = TriadeSubmissionService()
+    prepared = service.prepare_lote_envio(proponente_triade)
+    lote = prepared.lote
+    payload_snapshot = json.loads(lote.payload_envio)
+    batch_id = uuid4()
+
+    proponente_triade.razao_social = "Empresa Alterada Depois Do Snapshot"
+    proponente_triade.save(update_fields=("razao_social",))
+
+    mock_request.side_effect = [
+        DummyResponse(201, {"batch_id": str(batch_id), "status": "received"}),
+        DummyResponse(200, {"status": "processing"}),
+    ]
+
+    lote = service.retry_lote(lote)
+    lote.refresh_from_db()
+
+    assert mock_request.call_count == 2
+    assert (
+        mock_request.call_args_list[0].kwargs["json"]["applicant"]["name"]
+        == payload_snapshot["applicant"]["name"]
+    )
+    assert mock_request.call_args_list[0].kwargs["json"]["applicant"]["name"] == (
+        "Empresa Teste LTDA"
+    )
+    assert lote.batch_id == batch_id
+    assert lote.status == "processing"
+
+
+@patch("sme_uniforme_apps.triade.client.requests.Session.request")
+def test_retry_lote_com_batch_id_apenas_reinicia_pipeline(
+    mock_request, settings, proponente_triade, loja_primeira, anexo_triade
+):
+    configure_triade_settings(settings)
+    service = TriadeSubmissionService()
+    lote = service.prepare_lote_envio(proponente_triade).lote
+    lote.batch_id = uuid4()
+    lote.status = "error"
+    lote.save(update_fields=("batch_id", "status"))
+    mock_request.side_effect = [DummyResponse(409, {"detail": "pipeline ja iniciado"})]
+
+    lote = service.retry_lote(lote)
+    lote.refresh_from_db()
+
+    assert mock_request.call_count == 1
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://triade.exemplo.com/integration/v1/submissions/{}/start".format(
+            lote.batch_id
+        )
+    )
+    assert lote.status_http_inicio == 409
+
+
+def test_retry_lote_falha_sem_batch_id_e_sem_payload_persistido(
+    settings, proponente_triade, loja_primeira, anexo_triade
+):
+    configure_triade_settings(settings)
+    service = TriadeSubmissionService()
+    lote = service.prepare_lote_envio(proponente_triade).lote
+    lote.status = "error"
+    lote.payload_envio = None
+    lote.batch_id = None
+    lote.save(update_fields=("status", "payload_envio", "batch_id"))
+
+    with pytest.raises(TriadePermanentError, match="batch_id ou payload_envio"):
+        service.retry_lote(lote)
+
+
+def test_retry_lote_falha_quando_criacao_anterior_foi_erro_permanente(
+    settings, proponente_triade, loja_primeira, anexo_triade
+):
+    configure_triade_settings(settings)
+    service = TriadeSubmissionService()
+    lote = service.prepare_lote_envio(proponente_triade).lote
+    lote.status = "error"
+    lote.batch_id = None
+    lote.status_http_criacao = 422
+    lote.save(update_fields=("status", "batch_id", "status_http_criacao"))
+
+    with pytest.raises(TriadePermanentError, match="erro permanente de payload"):
+        service.retry_lote(lote)
+
+
+def test_task_reprocessar_lote_triade_tem_autoretry_configurado():
+    from sme_uniforme_apps.triade.tasks import reprocessar_lote_triade
+
+    assert TriadeTransientError in reprocessar_lote_triade.autoretry_for
+    assert reprocessar_lote_triade.retry_kwargs.get("max_retries") == 6
+    assert reprocessar_lote_triade.retry_backoff == 2


### PR DESCRIPTION
# Robustez e ações admin no TRIADE

Sem dependência entre si, migração de banco, mudança em dependências nem mudança de URL ou contrato externo.

## ✨ O que foi entregue

- **Preservação do status terminal em 409 do /start**: quando o POST /submissions/{id}/start retorna 409 sem campo status no corpo, o código antigo sobrescrevia o status terminal do lote (pending_review, completed ou error) com processing, apagando pareceres aplicados por callbacks anteriores. Agora preserva o status terminal nesse caso. Constante TRIADE_LOTE_TERMINAL_STATUSES extraída em statuses.py como fonte única da verdade.
- **Retry transitório em falha de banco no callback**: nova exceção TriadeCallbackTransientError. O process_callback separa OperationalError (transitória, retenta) de erro permanente. Task processar_callback_triade ganha autoretry_for com backoff de 2 e no máximo 6 tentativas, mesmo padrão já usado pela task de envio. Bugs de programação continuam morrendo na primeira tentativa.
- **Guard no admin de loja sem proponente**: LojaAdmin.protocolo retorna "-" em vez de levantar AttributeError quando a loja não tem proponente vinculado.
- **Serviço de retomada e sincronização no TriadeSubmissionService**: novos métodos retry_lote, retry_lote_id, get_retry_lote_blocker, _can_retry_create_same_snapshot, sync_lote, _apply_batch_sync_to_lote, _sync_documentos_from_batch e _parse_datetime. Constante TRIADE_LOTE_STATUSES_REPROCESSAVEIS (error, payload_ready, received). Task reprocessar_lote_triade recebe lote_id e tem autoretry_for=(TriadeTransientError,).
- **Duas actions no TriadeLoteAdmin**: retomar_processamento_na_triade enfileira reprocessar_lote_triade.delay(lote.id) preservando batch_id, payload_envio e documentos, com mensagens separadas para cada motivo de bloqueio (status inválido, sem snapshot, erro permanente anterior e falha de enfileiramento). sincronizar_com_triade chama service.sync_lote(lote) para lotes com batch_id e reporta sucesso, lotes sem batch_id e erros HTTP separadamente. A lista de status na mensagem de erro é gerada dinamicamente.

## 🔄 Cenários cobertos

- **A — /batches 422**: já funcionava, a ausência de batch_id faz o prepare_lote_envio reconstruir o payload com os dados corrigidos.
- **B transitório — /start 5xx**: já funcionava pelo autoretry_for da task de envio.
- **B permanente — /start 4xx**: novo. O retry_lote re-dispara apenas o /start (idempotente, 409 tratado como sucesso) e a action admin "Retomar processamento" permite recuperação manual. 4xx permanente na criação anterior é bloqueado, conforme o guia do TRIADE.
- **C Callback perdido ou atrasado**: novo. O sync_lote consulta o GET /batches/{id} e a action admin "Sincronizar" permite reconciliação manual. Limitação: o GET não traz decisao_parecer consolidado nem parecer_texto — só o callback traz.

## 🧪 Testes

Total passando: 66
Testes novos: 21

No test_submission_service.py, seis testes novos: 
- test_dispatch_com_409_no_start_preserva_status_terminal_do_lote
- test_retry_lote_sem_batch_id_reusa_snapshot_persistido
- test_retry_lote_com_batch_id_apenas_reinicia_pipeline
- test_retry_lote_falha_sem_batch_id_e_sem_payload_persistido
- test_retry_lote_falha_quando_criacao_anterior_foi_erro_permanente
- test_task_reprocessar_lote_triade_tem_autoretry_configurado

No test_callback_service.py, quatro novos: 
- test_process_callback_reseta_status_e_retry_em_operational_error
- test_process_callback_mantem_excecao_transiente_quando_reset_status_falha
- test_process_callback_marca_status_erro_em_excecao_permanente
- test_task_processar_callback_triade_tem_autoretry_configurado.

No test_admin.py, onze novos. 

- Cinco para a action de retomar 
  - _agenda_task_sem_limpar_estado
  - _ignora_status_terminal
  - _ignora_lote_sem_batch_e_sem_snapshot
  - _ignora_erro_permanente_de_criacao
  -  _processa_lote_misto) 
- Cinco para a de sincronizar
  - _atualiza_status_metadata_e_documentos
  - _ignora_lote_sem_batch_id
  - _registra_erro_em_resposta_nao_sucesso
  - _registra_erro_transiente_de_comunicacao
  - _processa_lote_misto)
- Classe auxiliar:
  - _DummyTriadeResponse que simula o retorno do cliente HTTP.

No test_loja/test_model.py:
- o novo test_admin_loja_protocolo_nao_quebra_sem_proponente confirma que o método retorna "-" quando a loja não tem proponente.

## 🚀 Como testar

- Suba o ambiente com:
`docker compose -f docker-compose-dev.yml up -d` 
- Rode: 
`docker compose -f docker-compose-dev.yml exec web pytest sme_uniforme_apps/triade/tests/ sme_uniforme_apps/proponentes/tests/test_loja/ -v. `
- O resultado esperado é 66 testes passando. 
- Para teste manual, acesse /admin/triade/triadelote/, filtre por status=error ou status=payload_ready, selecione lotes e dispare as ações "Retomar processamento na TRIADE" e "Sincronizar status e documentos com a TRIADE".
