### PR TITLE
Fix(148713): Ajuste Payload TRIADE e Labels Admin Anexos

### DIFF
--- a/sme_uniforme_apps/proponentes/admin.py
+++ b/sme_uniforme_apps/proponentes/admin.py
@@ -101,7 +101,9 @@ class AnexosInLine(admin.TabularInline):
 
     def justificativa_ia_info(self, obj):
         justificativa_ia = obj.justificativa_ia if obj and obj.justificativa_ia else ''
-        justificativa_data = justificativa_ia
+        justificativa_data = (
+            Anexo.remover_prefixo_analise_ia(justificativa_ia) if obj else ''
+        )
 
         if not justificativa_ia:
             return format_html(

--- a/sme_uniforme_apps/proponentes/models/anexo.py
+++ b/sme_uniforme_apps/proponentes/models/anexo.py
@@ -87,7 +87,17 @@ class Anexo(ModeloBase):
             and self.justificativa_ia
             and (sobrescrever or not self.justificativa)
         ):
-            self.justificativa = self.justificativa_ia
+            self.justificativa = self.remover_prefixo_analise_ia(
+                self.justificativa_ia
+            )
+
+    @staticmethod
+    def remover_prefixo_analise_ia(texto):
+        prefixo = "Análise da IA:"
+        texto = texto.lstrip()
+        if texto.lower().startswith(prefixo.lower()):
+            texto = texto[len(prefixo):].lstrip()
+        return texto
 
     class Meta:
         verbose_name = "Anexo"

--- a/sme_uniforme_apps/proponentes/tests/test_anexo/test_admin.py
+++ b/sme_uniforme_apps/proponentes/tests/test_anexo/test_admin.py
@@ -145,6 +145,31 @@ def test_inline_exibe_justificativa_ia_em_bloco_readonly_com_hook_js(anexo):
     assert 'data-justificativa-ia="Documento divergente segundo a IA."' in html
 
 
+def test_inline_remove_prefixo_analise_da_ia_do_data_atributo_para_hook_js(anexo):
+    inline = AnexosInLine(Proponente, AdminSite())
+    anexo.status_ia = Anexo.STATUS_REPROVADO
+    anexo.justificativa_ia = (
+        "Análise da IA: Documento divergente segundo a IA."
+    )
+
+    html = inline.justificativa_ia_info(anexo)
+
+    assert 'data-justificativa-ia="Documento divergente segundo a IA."' in html
+    assert (
+        "Análise da IA: Documento divergente segundo a IA." in html
+    ), "O texto completo com prefixo deve continuar visível no título e no corpo do details"
+
+
+def test_inline_remove_prefixo_analise_da_ia_com_espacos_e_caixa_alta(anexo):
+    inline = AnexosInLine(Proponente, AdminSite())
+    anexo.status_ia = Anexo.STATUS_REPROVADO
+    anexo.justificativa_ia = "   ANÁLISE DA IA:  Documento divergente."
+
+    html = inline.justificativa_ia_info(anexo)
+
+    assert 'data-justificativa-ia="Documento divergente."' in html
+
+
 def test_inline_deixa_justificativa_ia_vazia_quando_nao_ha_texto(anexo):
     inline = AnexosInLine(Proponente, AdminSite())
     anexo.justificativa_ia = ""

--- a/sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py
+++ b/sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py
@@ -107,6 +107,49 @@ def test_anexo_form_copia_justificativa_ia_para_admin(tipo_documento, status_adm
     assert form.cleaned_data["justificativa"] == "Documento divergente segundo a IA."
 
 
+@pytest.mark.parametrize("status_admin", [Anexo.STATUS_REPROVADO, Anexo.STATUS_VENCIDO])
+def test_anexo_form_remove_prefixo_analise_da_ia_ao_copiar_para_admin(
+    tipo_documento, status_admin
+):
+    anexo = Anexo(
+        tipo_documento=tipo_documento,
+        status_ia=Anexo.STATUS_REPROVADO,
+        justificativa_ia="Análise da IA: Documento divergente segundo a IA.",
+    )
+    form = AnexoForm(
+        data={
+            "tipo_documento": tipo_documento.id,
+            "status": status_admin,
+            "justificativa": "",
+        },
+        files={"arquivo": create_uploaded_file("anexo.pdf")},
+        instance=anexo,
+    )
+
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["justificativa"] == "Documento divergente segundo a IA."
+
+
+def test_anexo_preserva_justificativa_sem_prefixo_analise_da_ia(tipo_documento):
+    anexo = Anexo(
+        tipo_documento=tipo_documento,
+        status_ia=Anexo.STATUS_REPROVADO,
+        justificativa_ia="Documento divergente segundo a IA.",
+    )
+    form = AnexoForm(
+        data={
+            "tipo_documento": tipo_documento.id,
+            "status": Anexo.STATUS_REPROVADO,
+            "justificativa": "",
+        },
+        files={"arquivo": create_uploaded_file("anexo.pdf")},
+        instance=anexo,
+    )
+
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["justificativa"] == "Documento divergente segundo a IA."
+
+
 @pytest.mark.parametrize("file_name", ["anexo.jpg", "anexo.png", "anexo.txt"])
 def test_anexo_form_rejeita_arquivo_nao_pdf(tipo_documento, file_name):
     form = AnexoForm(

--- a/sme_uniforme_apps/triade/builders.py
+++ b/sme_uniforme_apps/triade/builders.py
@@ -1,6 +1,9 @@
 import base64
 import json
 import os
+import uuid
+
+from django.utils.text import slugify
 
 from sme_uniforme_apps.proponentes.cnpj import compact_cnpj
 
@@ -33,7 +36,7 @@ class TriadePayloadBuilder:
         external_batch_id = self._build_external_batch_id(external_batch_id)
         lojas = list(proponente.lojas.order_by("id"))
         primeira_loja = self._get_primeira_loja(lojas)
-        documentos = self._build_documents(proponente, anexos)
+        documentos = self._build_documents(proponente, lojas, anexos)
 
         payload = {
             "source_system": self.source_system,
@@ -94,20 +97,14 @@ class TriadePayloadBuilder:
         pontos_venda = []
         for loja in lojas:
             ponto_venda = {}
-            cidade = self._optional_value(
-                getattr(loja, "cidade", None)
-            ) or self._required_value(proponente.end_cidade, "proponente.end_cidade")
-            uf = self._optional_value(
-                getattr(loja, "uf", None)
-            ) or self._required_value(proponente.end_uf, "proponente.end_uf")
             campos = (
                 ("nome-loja", loja.nome_fantasia),
                 ("endereco", loja.endereco),
                 ("numero", loja.numero),
                 ("cep", loja.cep),
                 ("bairro", loja.bairro),
-                ("cidade", cidade),
-                ("uf", uf),
+                ("cidade", "São Paulo"),
+                ("uf", "SP"),
                 ("telefone", loja.telefone),
                 ("site", loja.site),
             )
@@ -121,7 +118,7 @@ class TriadePayloadBuilder:
 
         return pontos_venda
 
-    def _build_documents(self, proponente, anexos):
+    def _build_documents(self, proponente, lojas, anexos):
         anexos_ordenados = self._get_anexos(proponente, anexos)
         documentos = []
         external_document_ids = set()
@@ -166,7 +163,68 @@ class TriadePayloadBuilder:
                 }
             )
 
+        documentos.extend(
+            self._build_loja_documents(proponente, lojas, external_document_ids)
+        )
+
         return documentos
+
+    def _build_loja_documents(self, proponente, lojas, external_document_ids):
+        documentos = []
+        for loja in lojas:
+            for campo, prefixo_identificador in (
+                ("foto_fachada", "foto-fachada"),
+                ("comprovante_endereco", "comprovante-endereco"),
+            ):
+                arquivo = getattr(loja, campo, None)
+                if not arquivo:
+                    continue
+
+                nome_fantasia_slug = slugify(loja.nome_fantasia or "")
+                identificador = (
+                    "{}-{}-{}".format(
+                        prefixo_identificador, nome_fantasia_slug, loja.id
+                    )
+                    if nome_fantasia_slug
+                    else "{}-{}".format(prefixo_identificador, loja.id)
+                )
+                external_document_id = self._build_loja_external_document_id(
+                    loja, campo
+                )
+
+                if external_document_id in external_document_ids:
+                    raise TriadePayloadBuilderError(
+                        "TRIADE payload exige external_document_id unico dentro do lote."
+                    )
+                external_document_ids.add(external_document_id)
+
+                title = self._build_loja_document_title(arquivo, loja, campo)
+                mime_type = self._resolve_mime_type(arquivo)
+                content_data = self._build_loja_document_content(
+                    arquivo, loja, campo
+                )
+
+                documentos.append(
+                    {
+                        "external_document_id": external_document_id,
+                        "document_type": identificador,
+                        "title": title,
+                        "content": {
+                            "type": "base64",
+                            "mime_type": mime_type,
+                            "data": content_data,
+                        },
+                        "metadata": self._build_loja_document_metadata(
+                            proponente, loja, campo, identificador
+                        ),
+                    }
+                )
+
+        return documentos
+
+    @staticmethod
+    def _build_loja_external_document_id(loja, campo):
+        return str(uuid.uuid5(uuid.UUID(str(loja.uuid)), campo))
 
     def _build_document_metadata(self, proponente, anexo):
         metadata = {
@@ -242,6 +300,61 @@ class TriadePayloadBuilder:
             )
 
         return base64.b64encode(raw_content).decode("ascii")
+
+    def _build_loja_document_title(self, arquivo, loja, campo):
+        nome_arquivo = os.path.basename(arquivo.name or "")
+        if not nome_arquivo:
+            raise TriadePayloadBuilderError(
+                "TRIADE payload exige arquivo valido para o campo {} da loja {}.".format(
+                    campo, loja.uuid
+                )
+            )
+        return nome_arquivo
+
+    def _build_loja_document_content(self, arquivo, loja, campo):
+        try:
+            arquivo.open("rb")
+            raw_content = arquivo.read()
+        finally:
+            arquivo.close()
+
+        if not raw_content:
+            raise TriadePayloadBuilderError(
+                "TRIADE payload exige arquivo com conteudo para o campo {} da loja {}.".format(
+                    campo, loja.uuid
+                )
+            )
+
+        document_size = len(raw_content)
+        if document_size > self.MAX_DOCUMENT_SIZE_BYTES:
+            raise TriadePayloadBuilderError(
+                "TRIADE payload excede o limite de 15 MiB para o campo {} da loja {}.".format(
+                    campo, loja.uuid
+                )
+            )
+
+        return base64.b64encode(raw_content).decode("ascii")
+
+    def _build_loja_document_metadata(self, proponente, loja, campo, identificador):
+        nome_fantasia = self._optional_value(loja.nome_fantasia) or ""
+        return {
+            "loja_uuid": str(loja.uuid),
+            "loja_id": loja.id,
+            "loja_nome_fantasia": nome_fantasia,
+            "campo_loja": campo,
+            "proponente_uuid": str(proponente.uuid),
+            "tipo_documento_identificador": identificador,
+        }
+
+    def _resolve_mime_type(self, arquivo):
+        nome_arquivo = (arquivo.name or "").lower()
+        if nome_arquivo.endswith(".png"):
+            return "image/png"
+        if nome_arquivo.endswith((".jpg", ".jpeg")):
+            return "image/jpeg"
+        if nome_arquivo.endswith(".pdf"):
+            return "application/pdf"
+        return "application/octet-stream"
 
     def _get_anexos(self, proponente, anexos):
         if anexos is None:

--- a/sme_uniforme_apps/triade/builders.py
+++ b/sme_uniforme_apps/triade/builders.py
@@ -3,8 +3,6 @@ import json
 import os
 import uuid
 
-from django.utils.text import slugify
-
 from sme_uniforme_apps.proponentes.cnpj import compact_cnpj
 
 from .exceptions import TriadePermanentError
@@ -180,14 +178,7 @@ class TriadePayloadBuilder:
                 if not arquivo:
                     continue
 
-                nome_fantasia_slug = slugify(loja.nome_fantasia or "")
-                identificador = (
-                    "{}-{}-{}".format(
-                        prefixo_identificador, nome_fantasia_slug, loja.id
-                    )
-                    if nome_fantasia_slug
-                    else "{}-{}".format(prefixo_identificador, loja.id)
-                )
+                identificador = prefixo_identificador
                 external_document_id = self._build_loja_external_document_id(
                     loja, campo
                 )

--- a/sme_uniforme_apps/triade/tests/conftest.py
+++ b/sme_uniforme_apps/triade/tests/conftest.py
@@ -43,7 +43,25 @@ def arquivo_pdf():
 
 
 @pytest.fixture
-def loja_primeira(proponente_triade):
+def foto_fachada_arquivo():
+    return SimpleUploadedFile(
+        "fachada.jpg",
+        b"\xff\xd8\xff\xe0conteudo de fachada",
+        content_type="image/jpeg",
+    )
+
+
+@pytest.fixture
+def comprovante_endereco_arquivo():
+    return SimpleUploadedFile(
+        "comprovante.pdf",
+        b"%PDF-1.4 conteudo do comprovante",
+        content_type="application/pdf",
+    )
+
+
+@pytest.fixture
+def loja_primeira(proponente_triade, foto_fachada_arquivo, comprovante_endereco_arquivo):
     return baker.make(
         "Loja",
         proponente=proponente_triade,
@@ -54,11 +72,13 @@ def loja_primeira(proponente_triade):
         numero="100",
         telefone="(11) 3333-4444",
         site="https://primeira-loja.exemplo.com",
+        foto_fachada=foto_fachada_arquivo,
+        comprovante_endereco=comprovante_endereco_arquivo,
     )
 
 
 @pytest.fixture
-def loja_segunda(proponente_triade):
+def loja_segunda(proponente_triade, foto_fachada_arquivo, comprovante_endereco_arquivo):
     return baker.make(
         "Loja",
         proponente=proponente_triade,
@@ -68,6 +88,8 @@ def loja_segunda(proponente_triade):
         bairro="Bairro",
         numero="200",
         telefone="(11) 4444-5555",
+        foto_fachada=foto_fachada_arquivo,
+        comprovante_endereco=comprovante_endereco_arquivo,
     )
 
 

--- a/sme_uniforme_apps/triade/tests/test_payload_builder.py
+++ b/sme_uniforme_apps/triade/tests/test_payload_builder.py
@@ -1,6 +1,8 @@
 import base64
+import uuid
 
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from model_bakery import baker
 
 from sme_uniforme_apps.triade.builders import (
@@ -36,7 +38,7 @@ def test_build_payload_monta_payload_com_primeira_loja_e_documento(
             "numero": "100",
             "cep": "01001-000",
             "bairro": "Centro",
-            "cidade": "Sao Paulo",
+            "cidade": "São Paulo",
             "uf": "SP",
             "telefone": "(11) 3333-4444",
             "site": "https://primeira-loja.exemplo.com",
@@ -47,7 +49,7 @@ def test_build_payload_monta_payload_com_primeira_loja_e_documento(
             "numero": "200",
             "cep": "02002-000",
             "bairro": "Bairro",
-            "cidade": "Sao Paulo",
+            "cidade": "São Paulo",
             "uf": "SP",
             "telefone": "(11) 4444-5555",
         },
@@ -72,6 +74,89 @@ def test_build_payload_monta_payload_com_primeira_loja_e_documento(
     assert payload["metadata"]["status_atual_proponente"] == proponente_triade.status
     assert payload["metadata"]["origem_operacional"] == "concluir-cadastro"
     assert payload["metadata"]["fluxo"] == "mvp_conclusao_cadastro"
+
+
+def test_build_payload_monta_documentos_de_loja_com_foto_fachada_e_comprovante(
+    proponente_triade, loja_primeira, loja_segunda, anexo_triade
+):
+    builder = TriadePayloadBuilder(
+        source_system="portal_uniforme", schema_version="1.0"
+    )
+
+    payload = builder.build(proponente_triade, external_batch_id="PROTOCOLO-TRIADE-LOJAS")
+
+    documentos_loja = [
+        documento for documento in payload["documents"]
+        if documento["document_type"].startswith(("foto-fachada-", "comprovante-endereco-"))
+    ]
+    identificadores = [documento["document_type"] for documento in documentos_loja]
+    assert identificadores == [
+        "foto-fachada-loja-centro-{}".format(loja_primeira.id),
+        "comprovante-endereco-loja-centro-{}".format(loja_primeira.id),
+        "foto-fachada-loja-bairro-{}".format(loja_segunda.id),
+        "comprovante-endereco-loja-bairro-{}".format(loja_segunda.id),
+    ]
+
+    for documento in documentos_loja:
+        assert documento["title"]
+        assert documento["content"]["type"] == "base64"
+        assert documento["content"]["data"]
+        assert documento["metadata"]["loja_uuid"]
+        assert documento["metadata"]["proponente_uuid"] == str(proponente_triade.uuid)
+        assert documento["metadata"]["tipo_documento_identificador"] == documento["document_type"]
+
+    foto_fachada_centro = documentos_loja[0]
+    assert foto_fachada_centro["content"]["mime_type"] == "image/jpeg"
+    assert foto_fachada_centro["external_document_id"] == str(
+        uuid.uuid5(uuid.UUID(str(loja_primeira.uuid)), "foto_fachada")
+    )
+
+    comprovante_centro = documentos_loja[1]
+    assert comprovante_centro["content"]["mime_type"] == "application/pdf"
+    assert comprovante_centro["external_document_id"] == str(
+        uuid.uuid5(uuid.UUID(str(loja_primeira.uuid)), "comprovante_endereco")
+    )
+
+
+def test_build_payload_gera_identificadores_unicos_para_lojas_com_mesmo_nome_fantasia(
+    proponente_triade, loja_primeira, anexo_triade
+):
+    loja_mesmo_nome = baker.make(
+        "Loja",
+        proponente=proponente_triade,
+        nome_fantasia=loja_primeira.nome_fantasia,
+        cep="02002-000",
+        endereco="Rua Outra",
+        bairro="Outro Bairro",
+        numero="999",
+        telefone="(11) 9999-9999",
+        foto_fachada=SimpleUploadedFile(
+            "fachada2.jpg",
+            b"\xff\xd8\xff\xe0outra fachada",
+            content_type="image/jpeg",
+        ),
+        comprovante_endereco=SimpleUploadedFile(
+            "comprovante2.pdf",
+            b"%PDF-1.4 outro comprovante",
+            content_type="application/pdf",
+        ),
+    )
+
+    builder = TriadePayloadBuilder(
+        source_system="portal_uniforme", schema_version="1.0"
+    )
+    payload = builder.build(proponente_triade, external_batch_id="PROTOCOLO-TRIADE-DUP")
+
+    documentos_loja = [
+        documento for documento in payload["documents"]
+        if documento["document_type"].startswith(("foto-fachada-", "comprovante-endereco-"))
+    ]
+    identificadores = [documento["document_type"] for documento in documentos_loja]
+
+    assert len(identificadores) == len(set(identificadores))
+    assert "foto-fachada-loja-centro-{}".format(loja_primeira.id) in identificadores
+    assert "foto-fachada-loja-centro-{}".format(loja_mesmo_nome.id) in identificadores
+    assert loja_primeira.id != loja_mesmo_nome.id
 
 
 def test_build_payload_falha_sem_loja(proponente_triade, anexo_triade):

--- a/sme_uniforme_apps/triade/tests/test_payload_builder.py
+++ b/sme_uniforme_apps/triade/tests/test_payload_builder.py
@@ -87,14 +87,14 @@ def test_build_payload_monta_documentos_de_loja_com_foto_fachada_e_comprovante(
 
     documentos_loja = [
         documento for documento in payload["documents"]
-        if documento["document_type"].startswith(("foto-fachada-", "comprovante-endereco-"))
+        if documento["document_type"] in ("foto-fachada", "comprovante-endereco")
     ]
     identificadores = [documento["document_type"] for documento in documentos_loja]
     assert identificadores == [
-        "foto-fachada-loja-centro-{}".format(loja_primeira.id),
-        "comprovante-endereco-loja-centro-{}".format(loja_primeira.id),
-        "foto-fachada-loja-bairro-{}".format(loja_segunda.id),
-        "comprovante-endereco-loja-bairro-{}".format(loja_segunda.id),
+        "foto-fachada",
+        "comprovante-endereco",
+        "foto-fachada",
+        "comprovante-endereco",
     ]
 
     for documento in documentos_loja:
@@ -118,7 +118,7 @@ def test_build_payload_monta_documentos_de_loja_com_foto_fachada_e_comprovante(
     )
 
 
-def test_build_payload_gera_identificadores_unicos_para_lojas_com_mesmo_nome_fantasia(
+def test_build_payload_diferencia_lojas_via_external_document_id_e_metadata(
     proponente_triade, loja_primeira, anexo_triade
 ):
     loja_mesmo_nome = baker.make(
@@ -149,14 +149,25 @@ def test_build_payload_gera_identificadores_unicos_para_lojas_com_mesmo_nome_fan
 
     documentos_loja = [
         documento for documento in payload["documents"]
-        if documento["document_type"].startswith(("foto-fachada-", "comprovante-endereco-"))
+        if documento["document_type"] in ("foto-fachada", "comprovante-endereco")
     ]
-    identificadores = [documento["document_type"] for documento in documentos_loja]
+    identificadores = [documento["external_document_id"] for documento in documentos_loja]
 
     assert len(identificadores) == len(set(identificadores))
-    assert "foto-fachada-loja-centro-{}".format(loja_primeira.id) in identificadores
-    assert "foto-fachada-loja-centro-{}".format(loja_mesmo_nome.id) in identificadores
-    assert loja_primeira.id != loja_mesmo_nome.id
+
+    foto_fachada_primeira = next(
+        doc for doc in documentos_loja
+        if doc["document_type"] == "foto-fachada"
+        and doc["metadata"]["loja_id"] == loja_primeira.id
+    )
+    foto_fachada_mesmo_nome = next(
+        doc for doc in documentos_loja
+        if doc["document_type"] == "foto-fachada"
+        and doc["metadata"]["loja_id"] == loja_mesmo_nome.id
+    )
+    assert foto_fachada_primeira["document_type"] == foto_fachada_mesmo_nome["document_type"]
+    assert foto_fachada_primeira["external_document_id"] != foto_fachada_mesmo_nome["external_document_id"]
+    assert foto_fachada_primeira["metadata"]["loja_uuid"] != foto_fachada_mesmo_nome["metadata"]["loja_uuid"]
 
 
 def test_build_payload_falha_sem_loja(proponente_triade, anexo_triade):

--- a/sme_uniforme_apps/triade/tests/test_submission_service.py
+++ b/sme_uniforme_apps/triade/tests/test_submission_service.py
@@ -63,7 +63,7 @@ def test_prepare_lote_reconstroi_payload_persistido_quando_lote_ainda_nao_tem_ba
     assert prepared_rebuild.reused_payload is False
     assert (
         prepared_rebuild.payload["applicant"]["fields"]["ponto-venda"][0]["cidade"]
-        == "Sao Paulo"
+        == "São Paulo"
     )
     assert (
         prepared_rebuild.payload["applicant"]["fields"]["ponto-venda"][0]["uf"] == "SP"
@@ -124,9 +124,11 @@ def test_prepare_lote_envia_so_documentos_obrigatorios_quando_configurado_no_ban
         documento["external_document_id"] for documento in prepared.payload["documents"]
     ]
 
-    assert external_document_ids == [str(anexo_triade.uuid)]
+    assert str(anexo_triade.uuid) in external_document_ids
     assert str(anexo_opcional.uuid) not in external_document_ids
-    assert TriadeDocumento.objects.filter(lote=prepared.lote).count() == 1
+    assert TriadeDocumento.objects.filter(lote=prepared.lote).count() == len(
+        external_document_ids
+    )
 
 
 @patch("sme_uniforme_apps.triade.client.requests.Session.request")
@@ -178,10 +180,11 @@ def test_dispatch_proponente_envia_lote_e_inicia_pipeline(
     assert lote.payload_envio
     assert lote.ultimo_erro is None
 
-    documento = TriadeDocumento.objects.get(lote=lote)
+    documento = TriadeDocumento.objects.get(lote=lote, anexo=anexo_triade)
     assert documento.anexo_id == anexo_triade.id
     assert documento.external_document_id == str(anexo_triade.uuid)
     assert documento.document_type == anexo_triade.tipo_documento.identificador
+    assert TriadeDocumento.objects.filter(lote=lote).count() == 3
 
 
 @patch("sme_uniforme_apps.triade.client.requests.Session.request")


### PR DESCRIPTION
## Resumo

Esta PR aprimora o tratamento das justificativas geradas por IA no Admin e amplia a integração com a TRIADE, passando a incluir documentos das lojas no payload enviado para análise. Também foram adicionados testes para garantir a consistência dos novos comportamentos e regras de negócio.

### Melhorias no Tratamento de Justificativas da IA

* Ajustado o tratamento das justificativas para remover automaticamente o prefixo **"Análise da IA:"** quando o texto é utilizado em atributos de dados ou em ações de cópia no Admin.
* Mantida a exibição da justificativa completa na interface quando necessário, preservando o contexto para os usuários.
* Implementado tratamento para diferentes variações de espaçamento e capitalização do prefixo.
* Adicionados testes cobrindo:

  * Remoção correta do prefixo;
  * Preservação do conteúdo original na interface;
  * Cenários com variações de formatação;
  * Casos de borda relacionados ao texto da justificativa.

### Expansão do Payload da TRIADE

* Estendido o `TriadePayloadBuilder` para incluir documentos vinculados às lojas associadas ao proponente.
* Adicionado suporte aos documentos:

  * `foto_fachada`;
  * `comprovante_endereco`.
* Cada documento enviado passa a conter:

  * Identificador externo único;
  * Metadados da origem;
  * Conteúdo codificado;
  * Tipo MIME identificado automaticamente.
* Garantida a geração de identificadores únicos mesmo quando existirem lojas com nomes iguais.

  conforme regra de negócio definida para a integração.

### Cobertura de Testes

* Criadas fixtures para simular lojas contendo documentos anexados.
* Adicionados testes para validar:

  * Inclusão dos documentos das lojas no payload;
  * Geração correta dos identificadores externos;
  * Preenchimento dos metadados dos arquivos;
  * Conteúdo e tipo MIME enviados para a TRIADE;
  * Comportamento com múltiplas lojas de mesmo nome.
* Atualizados testes existentes para refletir:

  * Os novos valores de cidade e estado;
  * A quantidade esperada de documentos gerados e persistidos;
  * O novo formato do payload enviado à integração.

### Benefícios

* Melhor experiência de uso no Admin ao exibir e reutilizar justificativas geradas por IA.
* Payloads da TRIADE mais completos, contemplando documentos relevantes das lojas.
* Maior aderência às regras de negócio da integração.
* Cobertura de testes ampliada, reduzindo riscos de regressão e garantindo a confiabilidade do fluxo de envio para análise.
